### PR TITLE
feat(deepseek): add v4 model catalog entries

### DIFF
--- a/config/polaris.live-smoke.yaml
+++ b/config/polaris.live-smoke.yaml
@@ -121,7 +121,7 @@ providers:
         backoff: exponential
         initial_delay: 1s
     models:
-      use: [deepseek-chat]
+      use: [deepseek-chat, deepseek-v4-flash, deepseek-v4-pro]
 
   bytedance:
     transport:

--- a/config/providers/deepseek.yaml
+++ b/config/providers/deepseek.yaml
@@ -12,7 +12,7 @@ providers:
         backoff: exponential
         initial_delay: 1s
     models:
-      use: [deepseek-chat, deepseek-reasoner]
+      use: [deepseek-chat, deepseek-reasoner, deepseek-v4-flash, deepseek-v4-pro]
       overrides:
         deepseek-chat:
           context_window: 64000

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -225,6 +225,14 @@ The verification report checks configured canonical models, aliases, and selecto
 
 Model-taking API requests may also include a request-level `routing` object. Polaris merges those per-request hints with the static selector/config policy when the caller uses a family ID, family alias, or selector alias. Exact `provider/model` requests still bypass routing.
 
+DeepSeek uses the shared OpenAI-compatible chat-provider base. Configure:
+
+- `providers.deepseek.credentials.api_key`
+- optional `providers.deepseek.transport.base_url`
+- `providers.deepseek.models.use`
+
+The shipped DeepSeek snippet keeps `deepseek-chat` and `deepseek-reasoner` for compatibility and appends the official DeepSeek V4 Preview model IDs `deepseek-v4-flash` and `deepseek-v4-pro`. The existing `deepseek-chat` alias continues to resolve to `deepseek/deepseek-chat`; call V4 models by exact provider/model IDs such as `deepseek/deepseek-v4-flash` unless you intentionally add your own routing alias.
+
 Amazon Bedrock is intentionally separate from the OpenAI-compatible family. Configure:
 
 - `providers.bedrock.credentials.access_key_id`

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -28,7 +28,7 @@ Release rule for `v2.1.0`: every provider path described here as shipped and rel
 - Auth: OpenAI-compatible bearer token
 - Scope: chat
 - Status: implemented in Phase 2B
-- Notes: OpenAI-compatible chat completions; `reasoning_content` is currently stripped from the normalized Polaris response surface
+- Notes: OpenAI-compatible chat completions against the DeepSeek API base. Polaris keeps the legacy `deepseek-chat` and `deepseek-reasoner` IDs configured for compatibility and also includes the official DeepSeek V4 Preview IDs `deepseek-v4-flash` and `deepseek-v4-pro`. DeepSeek documents `deepseek-chat` and `deepseek-reasoner` as retiring after July 24, 2026, 15:59 UTC. `reasoning_content` is currently stripped from the normalized Polaris response surface.
 
 ### Google
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/gin-gonic/gin v1.12.0
 	github.com/gorilla/websocket v1.5.3
-	github.com/jackc/pgx/v5 v5.9.1
+	github.com/jackc/pgx/v5 v5.9.2
 	github.com/prometheus/client_golang v1.23.2
 	github.com/redis/go-redis/v9 v9.18.0
 	go.opentelemetry.io/otel v1.43.0

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.9.1 h1:uwrxJXBnx76nyISkhr33kQLlUqjv7et7b9FjCen/tdc=
-github.com/jackc/pgx/v5 v5.9.1/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -354,6 +354,46 @@ providers:
 	}
 }
 
+func TestLoadExpandsDeepSeekV4CatalogModelRefs(t *testing.T) {
+	configPath := writeTempConfig(t, `
+version: 2
+runtime:
+  server:
+    host: 127.0.0.1
+  auth:
+    mode: none
+providers:
+  deepseek:
+    credentials:
+      api_key: sk-test
+    transport:
+      base_url: https://api.deepseek.com/v1
+      timeout: 60s
+    models:
+      use: [deepseek-v4-flash, deepseek-v4-pro]
+`)
+
+	cfg, _, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	for _, name := range []string{"deepseek-v4-flash", "deepseek-v4-pro"} {
+		model := cfg.Providers["deepseek"].Models[name]
+		if model.Modality != "chat" {
+			t.Fatalf("%s modality = %q, want chat", name, model.Modality)
+		}
+		if model.ContextWindow != 1000000 {
+			t.Fatalf("%s context_window = %d, want 1000000", name, model.ContextWindow)
+		}
+		if model.MaxOutputTokens != 384000 {
+			t.Fatalf("%s max_output_tokens = %d, want 384000", name, model.MaxOutputTokens)
+		}
+		if !modelHasCapability(model, "reasoning") {
+			t.Fatalf("%s missing reasoning capability: %#v", name, model.Capabilities)
+		}
+	}
+}
+
 func TestLoadRejectsUnknownModelRefWithoutModality(t *testing.T) {
 	configPath := writeTempConfig(t, `
 version: 2
@@ -445,4 +485,13 @@ func writeTempConfig(t *testing.T, content string) string {
 		t.Fatalf("write temp config: %v", err)
 	}
 	return path
+}
+
+func modelHasCapability(model ModelConfig, capability string) bool {
+	for _, item := range model.Capabilities {
+		if string(item) == capability {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/gateway/handler/voice_stream.go
+++ b/internal/gateway/handler/voice_stream.go
@@ -121,6 +121,7 @@ func (h *VoiceHandler) StreamingTranscriptionWebSocket(c *gin.Context) {
 
 	var (
 		writeMu    sync.Mutex
+		outcomeMu  sync.Mutex
 		done       = make(chan struct{})
 		writerDone sync.WaitGroup
 		outcome    = middleware.RequestOutcome{
@@ -131,13 +132,23 @@ func (h *VoiceHandler) StreamingTranscriptionWebSocket(c *gin.Context) {
 			StatusCode:      http.StatusSwitchingProtocols,
 			TokenSource:     modality.TokenCountSourceUnavailable,
 		}
-		lastErrorTyp string
 	)
 
 	writeEvent := func(event modality.StreamingTranscriptionServerEvent) error {
 		writeMu.Lock()
 		defer writeMu.Unlock()
 		return conn.WriteJSON(event)
+	}
+	recordOutcomeError := func(errorType string) {
+		outcomeMu.Lock()
+		defer outcomeMu.Unlock()
+		outcome.ErrorType = errorType
+		outcome.StatusCode = http.StatusBadGateway
+	}
+	snapshotOutcome := func() middleware.RequestOutcome {
+		outcomeMu.Lock()
+		defer outcomeMu.Unlock()
+		return outcome
 	}
 
 	writerDone.Add(1)
@@ -153,8 +164,7 @@ func (h *VoiceHandler) StreamingTranscriptionWebSocket(c *gin.Context) {
 					return
 				}
 				if event.Error != nil && strings.TrimSpace(event.Error.Type) != "" {
-					lastErrorTyp = event.Error.Type
-					outcome.StatusCode = http.StatusBadGateway
+					recordOutcomeError(event.Error.Type)
 				}
 				if err := writeEvent(event); err != nil {
 					return
@@ -184,8 +194,7 @@ func (h *VoiceHandler) StreamingTranscriptionWebSocket(c *gin.Context) {
 		var event modality.StreamingTranscriptionClientEvent
 		if err := conn.ReadJSON(&event); err != nil {
 			if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
-				lastErrorTyp = "provider_transport_error"
-				outcome.StatusCode = http.StatusBadGateway
+				recordOutcomeError("provider_transport_error")
 			}
 			break
 		}
@@ -213,8 +222,7 @@ func (h *VoiceHandler) StreamingTranscriptionWebSocket(c *gin.Context) {
 
 	close(done)
 	writerDone.Wait()
-	outcome.ErrorType = lastErrorTyp
-	middleware.SetRequestOutcome(c, outcome)
+	middleware.SetRequestOutcome(c, snapshotOutcome())
 }
 
 func validateStreamingTranscriptionRequest(req *modality.StreamingTranscriptionSessionConfig) error {

--- a/internal/gateway/server_test.go
+++ b/internal/gateway/server_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -2616,6 +2617,12 @@ func TestMetricsCaptureFailoverAndRateLimit(t *testing.T) {
 func TestMetricsActiveStreamsGaugeTracksInFlightStreams(t *testing.T) {
 	streamStarted := make(chan struct{})
 	releaseStream := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() {
+			close(releaseStream)
+		})
+	}
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
@@ -2662,6 +2669,7 @@ func TestMetricsActiveStreamsGaugeTracksInFlightStreams(t *testing.T) {
 
 	server := httptest.NewServer(engine)
 	defer server.Close()
+	defer release()
 
 	client := server.Client()
 	streamDone := make(chan string, 1)
@@ -2695,23 +2703,42 @@ func TestMetricsActiveStreamsGaugeTracksInFlightStreams(t *testing.T) {
 		t.Fatal("timed out waiting for stream to start")
 	}
 
-	metricsResp, err := client.Get(server.URL + "/metrics")
-	if err != nil {
-		t.Fatalf("GET /metrics error = %v", err)
+	readMetrics := func() string {
+		t.Helper()
+
+		metricsResp, err := client.Get(server.URL + "/metrics")
+		if err != nil {
+			t.Fatalf("GET /metrics error = %v", err)
+		}
+		bodyBytes, err := io.ReadAll(metricsResp.Body)
+		if closeErr := metricsResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close metrics body: %v", closeErr)
+		}
+		if err != nil {
+			t.Fatalf("read metrics body: %v", err)
+		}
+		return string(bodyBytes)
 	}
-	bodyBytes, err := io.ReadAll(metricsResp.Body)
-	if closeErr := metricsResp.Body.Close(); closeErr != nil {
-		t.Fatalf("close metrics body: %v", closeErr)
-	}
-	if err != nil {
-		t.Fatalf("read metrics body: %v", err)
-	}
-	body := string(bodyBytes)
-	if !strings.Contains(body, `polaris_active_streams{model="openai/gpt-4o",provider="openai"} 1`) {
-		t.Fatalf("expected active stream gauge to be 1, got %s", body)
+	waitForMetric := func(expected string) string {
+		t.Helper()
+
+		deadline := time.Now().Add(2 * time.Second)
+		var body string
+		for {
+			body = readMetrics()
+			if strings.Contains(body, expected) {
+				return body
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("expected metrics to contain %q, got %s", expected, body)
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
 	}
 
-	close(releaseStream)
+	waitForMetric(`polaris_active_streams{model="openai/gpt-4o",provider="openai"} 1`)
+
+	release()
 
 	select {
 	case payload := <-streamDone:
@@ -2722,21 +2749,7 @@ func TestMetricsActiveStreamsGaugeTracksInFlightStreams(t *testing.T) {
 		t.Fatal("timed out waiting for stream completion")
 	}
 
-	metricsResp, err = client.Get(server.URL + "/metrics")
-	if err != nil {
-		t.Fatalf("GET /metrics error = %v", err)
-	}
-	bodyBytes, err = io.ReadAll(metricsResp.Body)
-	if closeErr := metricsResp.Body.Close(); closeErr != nil {
-		t.Fatalf("close metrics body: %v", closeErr)
-	}
-	if err != nil {
-		t.Fatalf("read metrics body: %v", err)
-	}
-	body = string(bodyBytes)
-	if !strings.Contains(body, `polaris_active_streams{model="openai/gpt-4o",provider="openai"} 0`) {
-		t.Fatalf("expected active stream gauge to return to 0, got %s", body)
-	}
+	waitForMetric(`polaris_active_streams{model="openai/gpt-4o",provider="openai"} 0`)
 }
 
 func testConfig(t *testing.T) *config.Config {

--- a/internal/provider/catalog/catalog_test.go
+++ b/internal/provider/catalog/catalog_test.go
@@ -21,12 +21,36 @@ func TestDefaultCatalogLoadsAndValidates(t *testing.T) {
 	if _, ok := cat.Lookup("openai/gpt-image-2"); !ok {
 		t.Fatal("expected openai/gpt-image-2 in embedded catalog")
 	}
+	for _, id := range []string{"deepseek/deepseek-v4-flash", "deepseek/deepseek-v4-pro"} {
+		entry, ok := cat.Lookup(id)
+		if !ok {
+			t.Fatalf("expected %s in embedded catalog", id)
+		}
+		if entry.ContextWindow != 1000000 {
+			t.Fatalf("%s context_window = %d, want 1000000", id, entry.ContextWindow)
+		}
+		if entry.MaxOutputTokens != 384000 {
+			t.Fatalf("%s max_output_tokens = %d, want 384000", id, entry.MaxOutputTokens)
+		}
+		if !entryHasCapability(entry, "reasoning") {
+			t.Fatalf("%s missing reasoning capability: %#v", id, entry.Capabilities)
+		}
+	}
 	if target, ok := cat.AliasTarget("GLM-5.1"); !ok || target != "glm/glm-5.1" {
 		t.Fatalf("alias target = %q, %v", target, ok)
 	}
 	if family, ok := cat.Family("gpt-5.4"); !ok || family.DisplayName != "GPT-5.4" {
 		t.Fatalf("family = %#v, %v", family, ok)
 	}
+}
+
+func entryHasCapability(entry Entry, capability string) bool {
+	for _, item := range entry.Capabilities {
+		if string(item) == capability {
+			return true
+		}
+	}
+	return false
 }
 
 func TestParseCatalogRejectsAliasCollision(t *testing.T) {

--- a/internal/provider/catalog/models.yaml
+++ b/internal/provider/catalog/models.yaml
@@ -135,6 +135,42 @@ models:
     verification_class: strict
     doc_url: https://api-docs.deepseek.com/
     last_verified: "2026-04-22"
+  - provider: deepseek
+    model_id: deepseek-v4-flash
+    display_name: DeepSeek V4 Flash
+    aliases: []
+    family_id: deepseek-v4-flash
+    family_display_name: DeepSeek V4 Flash
+    family_aliases: ["DeepSeek V4 Flash"]
+    family_priority: 10
+    modality: chat
+    capabilities: [streaming, function_calling, json_mode, reasoning]
+    context_window: 1000000
+    max_output_tokens: 384000
+    cost_tier: low
+    latency_tier: fast
+    status: preview
+    verification_class: opt_in
+    doc_url: https://api-docs.deepseek.com/news/news260424
+    last_verified: "2026-04-26"
+  - provider: deepseek
+    model_id: deepseek-v4-pro
+    display_name: DeepSeek V4 Pro
+    aliases: []
+    family_id: deepseek-v4-pro
+    family_display_name: DeepSeek V4 Pro
+    family_aliases: ["DeepSeek V4 Pro"]
+    family_priority: 10
+    modality: chat
+    capabilities: [streaming, function_calling, json_mode, reasoning]
+    context_window: 1000000
+    max_output_tokens: 384000
+    cost_tier: premium
+    latency_tier: best_quality
+    status: preview
+    verification_class: opt_in
+    doc_url: https://api-docs.deepseek.com/news/news260424
+    last_verified: "2026-04-26"
 
   - provider: featherless
     model_id: meta-llama/Meta-Llama-3.1-8B-Instruct

--- a/internal/provider/deepseek/chat_test.go
+++ b/internal/provider/deepseek/chat_test.go
@@ -2,6 +2,7 @@ package deepseek
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -56,6 +57,51 @@ func TestChatAdapterComplete(t *testing.T) {
 	}
 	if len(response.Choices) != 1 || response.Choices[0].Message.Content.Text == nil || *response.Choices[0].Message.Content.Text != "Hello" {
 		t.Fatalf("unexpected response %#v", response)
+	}
+}
+
+func TestChatAdapterUsesV4ProviderModel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload struct {
+			Model string `json:"model"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if payload.Model != "deepseek-v4-pro" {
+			t.Fatalf("provider model = %q, want deepseek-v4-pro", payload.Model)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-v4",
+			"object":"chat.completion",
+			"created":1777161600,
+			"model":"deepseek-v4-pro",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"V4"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":4,"completion_tokens":2,"total_tokens":6}
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(config.ProviderConfig{
+		APIKey:  "sk-deepseek",
+		BaseURL: server.URL + "/v1",
+		Timeout: time.Second,
+	})
+	adapter := NewChatAdapter(client, "deepseek/deepseek-v4-pro")
+
+	response, err := adapter.Complete(context.Background(), &modality.ChatRequest{
+		Model: "deepseek/deepseek-v4-pro",
+		Messages: []modality.ChatMessage{
+			{Role: "user", Content: modality.NewTextContent("Hello")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if response.Model != "deepseek/deepseek-v4-pro" {
+		t.Fatalf("expected canonical model, got %q", response.Model)
 	}
 }
 

--- a/tests/e2e/live_smoke_cases_core.go
+++ b/tests/e2e/live_smoke_cases_core.go
@@ -221,6 +221,32 @@ func liveSmokeCoreCases() []liveSmokeCase {
 				harness.requireContains(t, resp, "DEEPSEEK_OK")
 			},
 		},
+		{
+			name:       "deepseek_v4_flash",
+			modelNames: []string{"deepseek/deepseek-v4-flash"},
+			run: func(t *testing.T, ctx context.Context, harness *liveSmokeHarness) {
+				policy := harness.gateCase(t, "DeepSeek V4 Flash", "deepseek/deepseek-v4-flash")
+				harness.requireEnv(t, policy, "DeepSeek V4 Flash", "DEEPSEEK_API_KEY")
+				resp, err := harness.chat(ctx, "deepseek/deepseek-v4-flash", "Reply with DEEPSEEK_V4_FLASH_OK only.")
+				if err != nil {
+					t.Fatalf("DeepSeek V4 Flash smoke failed: %v", err)
+				}
+				harness.requireContains(t, resp, "DEEPSEEK_V4_FLASH_OK")
+			},
+		},
+		{
+			name:       "deepseek_v4_pro",
+			modelNames: []string{"deepseek/deepseek-v4-pro"},
+			run: func(t *testing.T, ctx context.Context, harness *liveSmokeHarness) {
+				policy := harness.gateCase(t, "DeepSeek V4 Pro", "deepseek/deepseek-v4-pro")
+				harness.requireEnv(t, policy, "DeepSeek V4 Pro", "DEEPSEEK_API_KEY")
+				resp, err := harness.chat(ctx, "deepseek/deepseek-v4-pro", "Reply with DEEPSEEK_V4_PRO_OK only.")
+				if err != nil {
+					t.Fatalf("DeepSeek V4 Pro smoke failed: %v", err)
+				}
+				harness.requireContains(t, resp, "DEEPSEEK_V4_PRO_OK")
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
## What
Adds official DeepSeek V4 Preview model support to Polaris, fixes the CI race exposed by the PR run, resolves the open Dependabot pgx advisory on the default branch once merged, and stabilizes a Linux-only metric test race found by the hosted runner:

- Adds `deepseek-v4-flash` and `deepseek-v4-pro` to the embedded provider catalog.
- Appends both models to the DeepSeek provider snippet and live-smoke config.
- Keeps existing `deepseek-chat` / `deepseek-reasoner` support and existing aliases unchanged.
- Updates provider/configuration docs and adds focused catalog, config, adapter, and live-smoke metadata tests.
- Guards streaming transcription outcome state shared across websocket/provider goroutines, fixing the original `go test -race ./...` failure in CI.
- Updates `github.com/jackc/pgx/v5` from `v5.9.1` to `v5.9.2` for GHSA-j88v-2chj-qfwx.
- Stabilizes `TestMetricsActiveStreamsGaugeTracksInFlightStreams` so it releases the held stream on failure and waits for the active-stream gauge to reach the expected value.

## Why
DeepSeek has published V4 Preview models in the official API docs. Polaris should expose these as catalog-backed, config-driven provider models while preserving current routing behavior for existing users. The CI run also surfaced an existing streaming transcription data race, which blocked this PR until the race was fixed. GitHub Dependabot reports `github.com/jackc/pgx/v5 < 5.9.2` as vulnerable on the default branch, so this PR now carries the patched dependency version. The hosted Linux runner also exposed a scheduler-sensitive test assertion around active stream metrics; the test now waits for the metric transition instead of assuming an immediate scheduling order.

## How
- Added V4 model metadata with chat modality, streaming/function-calling/json/reasoning capabilities, official context/output limits, preview status, and opt-in verification.
- Reused the existing DeepSeek OpenAI-compatible adapter path without special-casing transport or request translation.
- Added live-smoke entries for exact `provider/model` calls so V4 can be proven through the Polaris gateway without changing the `deepseek-chat` alias.
- Added a mutex-protected outcome snapshot in the streaming transcription websocket handler so the provider event goroutine and client read loop no longer write shared request outcome state concurrently.
- Ran `go get github.com/jackc/pgx/v5@v5.9.2` and `go mod tidy` so `go.mod` and `go.sum` resolve the patched pgx release.
- Added one-shot release cleanup and metric polling to the active-stream gauge test to avoid hanging `httptest.Server.Close` after an assertion failure.

## Gameplay impact
None.

## Screenshots / GIFs
N/A.

## Video clip
N/A.

## Testing done
- `go test -count=1 ./internal/provider/catalog ./internal/config ./internal/provider/deepseek ./internal/provider`
- `go test -count=1 ./tests/e2e -run 'TestLiveSmokeCasesHaveVerificationMetadata|TestLiveSmokeOptInEnabled|TestLiveSmokeProviderOptInName'`
- `make config-check`
- `make fmt-check`
- `make lint`
- `make security-check`
- `go test -race ./internal/gateway -run 'Test.*Streaming' -count=1`
- `go test -race ./internal/gateway -run TestMetricsActiveStreamsGaugeTracksInFlightStreams -count=20`
- `docker run --rm -v "$PWD":/src -w /src golang:1.26.2-alpine sh -lc 'apk add --no-cache gcc musl-dev >/dev/null && /usr/local/go/bin/go test -race ./internal/gateway -run TestMetricsActiveStreamsGaugeTracksInFlightStreams -count=20'`
- `go clean -testcache && make test`
- `make build`
- `make docker-build`
- `go list -m github.com/jackc/pgx/v5` -> `v5.9.2`
- Live Polaris gateway smoke with temporary DeepSeek test credentials:
  - `TestLiveSmokeMatrix/deepseek_chat`
  - `TestLiveSmokeMatrix/deepseek_v4_flash`
  - `TestLiveSmokeMatrix/deepseek_v4_pro`

## Platform notes
N/A.

## Performance considerations
No meaningful runtime overhead. The gateway fix adds a tiny mutex around websocket outcome bookkeeping only on streaming transcription close/error paths. The active-stream metric change is test-only.

## Known limitations
DeepSeek `reasoning_content` remains omitted from the normalized Polaris response surface, matching the existing adapter behavior. DeepSeek V4 models are marked `opt_in` because the official release is Preview.
