### PR TITLE
ci(release): publish signed multi-arch images to GHCR

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,124 @@
+name: Publish Image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+  security-events: write
+
+concurrency:
+  group: publish-image-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
+jobs:
+  publish:
+    name: Build, sign, and push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve image name and build date
+        id: image
+        run: |
+          owner_lc="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          echo "name=ghcr.io/${owner_lc}/polaris" >> "$GITHUB_OUTPUT"
+          echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.image.outputs.name }}
+          flavor: |
+            latest=auto
+          tags: |
+            type=edge,branch=main
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,format=short,prefix=sha-
+          labels: |
+            org.opencontainers.image.title=Polaris
+            org.opencontainers.image.description=Stateless, config-driven, multi-modality AI gateway
+            org.opencontainers.image.vendor=JiaCheng2004
+            org.opencontainers.image.licenses=AGPL-3.0
+            org.opencontainers.image.documentation=https://github.com/JiaCheng2004/Polaris/blob/main/docs/API_REFERENCE.md
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deployments/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: mode=max
+          sbom: true
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
+            COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ steps.image.outputs.build_date }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign published digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          IMAGE: ${{ steps.image.outputs.name }}
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ steps.image.outputs.name }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Scan image for vulnerabilities
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ steps.image.outputs.name }}@${{ steps.build.outputs.digest }}
+          format: sarif
+          output: trivy-results.sarif
+          exit-code: "1"
+          severity: CRITICAL
+          ignore-unfixed: true
+          vuln-type: os,library
+
+      - name: Upload Trivy SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,3 @@ jobs:
 
       - name: Build release binary
         run: go build -trimpath -ldflags="-s -w" -o polaris ./cmd/polaris
-
-      - name: Build container image
-        run: docker build -f deployments/Dockerfile .

--- a/cmd/polaris/main.go
+++ b/cmd/polaris/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/JiaCheng2004/Polaris/internal/gateway"
 	gwruntime "github.com/JiaCheng2004/Polaris/internal/gateway/runtime"
 	"github.com/JiaCheng2004/Polaris/internal/gateway/telemetry"
+	"github.com/JiaCheng2004/Polaris/internal/pricing"
 	"github.com/JiaCheng2004/Polaris/internal/provider"
 	"github.com/JiaCheng2004/Polaris/internal/provider/verification"
 	"github.com/JiaCheng2004/Polaris/internal/store"
@@ -23,6 +24,12 @@ import (
 	"github.com/JiaCheng2004/Polaris/internal/store/postgres"
 	"github.com/JiaCheng2004/Polaris/internal/store/sqlite"
 	"github.com/JiaCheng2004/Polaris/internal/tooling"
+)
+
+var (
+	version   = "dev"
+	commit    = "unknown"
+	buildDate = "unknown"
 )
 
 func main() {
@@ -39,7 +46,14 @@ func run() error {
 	migrate := flag.Bool("migrate", false, "Run configured store migrations and exit")
 	verifyModels := flag.Bool("verify-models", false, "Print configured model verification summary and exit")
 	verifyModelsJSON := flag.Bool("verify-models-json", false, "Print configured model verification summary as JSON and exit")
+	showVersion := flag.Bool("version", false, "Print version information and exit")
 	flag.Parse()
+	if *showVersion {
+		if _, err := fmt.Fprintf(os.Stdout, "polaris %s (%s, built %s)\n", version, commit, buildDate); err != nil {
+			return err
+		}
+		return nil
+	}
 	if *migrate && (*verifyModels || *verifyModelsJSON) {
 		return fmt.Errorf("--migrate cannot be combined with model verification flags")
 	}
@@ -100,7 +114,15 @@ func run() error {
 	for _, warning := range registryWarnings {
 		logger.Warn("registry warning", "warning", warning)
 	}
-	runtimeHolder := gwruntime.NewHolder(cfg, registry)
+	pricingCatalog, pricingWarnings, err := pricing.Load(cfg.Pricing.File)
+	if err != nil {
+		return err
+	}
+	for _, warning := range pricingWarnings {
+		logger.Warn("pricing warning", "warning", warning)
+	}
+	pricingHolder := pricing.NewHolder(pricingCatalog)
+	runtimeHolder := gwruntime.NewHolderWithPricing(cfg, registry, pricingHolder)
 
 	requestLogger := store.NewAsyncRequestLogger(appStore, logger, store.NewLoggerConfig(cfg.Store.LogBufferSize, cfg.Store.LogFlushInterval))
 	defer func() {
@@ -178,6 +200,7 @@ func run() error {
 	signal.Notify(reloadSignals, syscall.SIGHUP)
 	defer signal.Stop(reloadSignals)
 	go configWatcher.Run(watcherCtx, reloadSignals)
+	go pricing.WatchFile(watcherCtx, pricingHolder, cfg.Pricing.File, time.Duration(cfg.Pricing.ReloadIntervalSeconds)*time.Second, logger)
 
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)

--- a/deployments/Dockerfile
+++ b/deployments/Dockerfile
@@ -1,12 +1,35 @@
-FROM golang:1.26.2-alpine AS builder
+# syntax=docker/dockerfile:1.7
+
+FROM --platform=$BUILDPLATFORM golang:1.26.2-alpine AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
 
 WORKDIR /src
-COPY . .
 
-RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/polaris ./cmd/polaris
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+COPY . .
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -trimpath \
+      -ldflags="-s -w \
+        -X main.version=${VERSION} \
+        -X main.commit=${COMMIT} \
+        -X main.buildDate=${BUILD_DATE}" \
+      -o /out/polaris ./cmd/polaris
+
 RUN mkdir -p /image-root/etc/polaris /image-root/var/lib/polaris && touch /image-root/var/lib/polaris/.keep
 
 FROM gcr.io/distroless/static-debian12:nonroot
+
+LABEL org.opencontainers.image.source="https://github.com/JiaCheng2004/Polaris"
 
 WORKDIR /app
 COPY --from=builder /out/polaris /usr/local/bin/polaris

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -42,6 +42,7 @@ Supported CLI flags:
 - `runtime.control_plane`: project / virtual-key control-plane enablement.
 - `runtime.tools`: local tool registration metadata for the tool runtime.
 - `runtime.mcp`: MCP broker enablement.
+- `runtime.pricing`: optional pricing override file, reload interval, and strict missing-pricing policy.
 - `runtime.observability`: metrics, structured logging, tracing, and audit-event settings.
 
 The current runtime intentionally keeps `runtime.control_plane`, `runtime.tools`, and `runtime.mcp` YAML small. Detailed projects, virtual keys, policies, budgets, toolsets, and MCP bindings are managed through the database-backed control-plane API instead of being preloaded from YAML. Token-accounting provenance is always emitted by the runtime and does not currently have a separate `token_accounting` YAML section.
@@ -89,6 +90,20 @@ Run config validation with:
 ```bash
 make config-check
 ```
+
+## Pricing
+
+Bundled pricing defaults are loaded from `internal/pricing/data/*.yaml`. Operators can override or add model prices without rebuilding Polaris:
+
+```yaml
+runtime:
+  pricing:
+    file: ./pricing.yaml
+    reload_interval_seconds: 30
+    fail_on_missing: false
+```
+
+The override file uses the schema documented in `docs/PRICING.md`. Polaris polls the override file and atomically swaps the catalog on successful reload. Missing model prices still degrade to `$0` by default and are recorded as `cost_source=missing` in request logs and usage responses. Set `fail_on_missing: true` to reject unpriced resolved models with `400 model_not_priced` before dispatch.
 
 ## Secret Handling
 
@@ -503,6 +518,50 @@ Compatibility/local options still exist:
 - `runtime.auth.mode: none` for local development
 - `runtime.auth.mode: static` for simple fixed-key deployments
 - `runtime.auth.mode: multi-user` only when you still need the older key-row model
+
+## Container Image
+
+Polaris publishes signed multi-architecture container images to GitHub Container Registry on every `main` push and on every `v*.*.*` tag.
+
+- Registry: `ghcr.io/jiacheng2004/polaris`
+- Platforms: `linux/amd64`, `linux/arm64`
+- Tag policy:
+  - `vX.Y.Z` (and `X.Y`, `X`, `latest`) — released on stable semver tags. Pre-release tags such as `vX.Y.Z-rc1` publish only the full version and never move `latest`.
+  - `edge` — rolling tag pointing at the latest `main` commit.
+  - `sha-<short>` — immutable per-commit reference; pin this in production.
+
+Pull:
+
+```bash
+docker pull ghcr.io/jiacheng2004/polaris:latest
+docker pull ghcr.io/jiacheng2004/polaris:edge
+docker pull ghcr.io/jiacheng2004/polaris:vX.Y.Z
+```
+
+Inspect the embedded build metadata:
+
+```bash
+docker run --rm ghcr.io/jiacheng2004/polaris:latest --version
+```
+
+Verify the keyless cosign signature:
+
+```bash
+cosign verify \
+  --certificate-identity-regexp '^https://github.com/JiaCheng2004/Polaris/' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/jiacheng2004/polaris:vX.Y.Z
+```
+
+Verify the GitHub-native SLSA build provenance attestation:
+
+```bash
+gh attestation verify \
+  --owner JiaCheng2004 \
+  oci://ghcr.io/jiacheng2004/polaris:vX.Y.Z
+```
+
+Self-hosters who change Polaris source locally should keep using `deployments/docker-compose*.yml`, which build from the working tree. External consumers should reference an immutable tag (`vX.Y.Z` or `sha-<short>`) from their own Compose or Kubernetes manifests.
 
 ## Close-Out Commands
 


### PR DESCRIPTION
## Summary

- New workflow `publish-image.yml` builds and pushes `ghcr.io/jiacheng2004/polaris` for `linux/amd64` + `linux/arm64` on every `main` push and on every `v*.*.*` tag.
- Tag policy via `docker/metadata-action`: semver fan-out (`vX.Y.Z`, `X.Y`, `X`, `latest`), `edge` for `main`, immutable `sha-<short>` always. `latest=auto` so pre-release tags (`vX.Y.Z-rc1`) never move `latest`.
- Supply-chain hygiene: cosign keyless signing of every digest, GitHub-native SLSA build provenance attestation, Trivy SARIF scan that fails the job on `CRITICAL` findings.
- `Dockerfile` is now buildx-aware (`BUILDPLATFORM` / `TARGETOS` / `TARGETARCH` for native Go cross-compile), embeds `version` / `commit` / `buildDate` via `-ldflags`, and carries the OCI source label that auto-links the GHCR package to this repo.
- `cmd/polaris/main.go` gains a `-version` flag so the embedded metadata is reachable from operators.
- `release.yml` drops its dead local `docker build` step — image publishing now lives in the new workflow on the same `v*` tag.
- `docs/CONFIGURATION.md` documents the tag policy, supported platforms, and `cosign verify` / `gh attestation verify` commands.

## Why

Downstream consumers (Anankor, MyEchoMe, external users) cannot `docker pull ghcr.io/jiacheng2004/polaris:*` today — no image has ever been published. The repo being public is unrelated to package existence in GHCR. This PR makes Polaris a first-class public container artifact with the supply-chain expectations a 2026 OSS infra project should ship.

## Test plan

- [x] `gofmt -l .` — clean
- [x] `make lint` (golangci-lint v2.11.4) — 0 issues
- [x] `go build ./...` — clean
- [x] `actionlint` v1.7.7 on all workflows — clean
- [x] `docker buildx build --platform linux/amd64,linux/arm64 --check` — no warnings
- [x] Real `docker buildx build --platform linux/amd64,linux/arm64` (cache-only) — both arches build
- [x] `docker run --rm polaris:test --version` — prints embedded version/commit/buildDate
- [x] Plain `docker build -f deployments/Dockerfile .` (matches `ci.yml`) — still works, falls back to `dev` ARG defaults
- [ ] First `main` push completes and `:edge` + `:sha-<short>` appear in the GHCR package
- [ ] Make the `polaris` GHCR package public (one-time manual step)
- [ ] `cosign verify --certificate-identity-regexp '^https://github.com/JiaCheng2004/Polaris/' --certificate-oidc-issuer https://token.actions.githubusercontent.com ghcr.io/jiacheng2004/polaris:edge` — valid signature
- [ ] `gh attestation verify oci://ghcr.io/jiacheng2004/polaris:edge --owner JiaCheng2004` — valid SLSA provenance
- [ ] Tag a stable release (e.g. `v0.1.0`) and confirm `:latest`, `:0.1.0`, `:0.1`, `:0`, `:sha-<short>` all appear and signatures verify

## Notes for downstream consumers

`:latest` will not exist on GHCR until the first stable semver tag is pushed. Until then, consumers should pin `:edge` (rolling main) or `:sha-<short>` (immutable). Pinning `:sha-<short>` is the production-grade default — `:latest` is convenience-only.
