### PR TITLE
feat(pricing): hot-reloadable cost engine with per-dimension accounting

### DIFF
--- a/cmd/polaris/main.go
+++ b/cmd/polaris/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/JiaCheng2004/Polaris/internal/gateway"
 	gwruntime "github.com/JiaCheng2004/Polaris/internal/gateway/runtime"
 	"github.com/JiaCheng2004/Polaris/internal/gateway/telemetry"
+	"github.com/JiaCheng2004/Polaris/internal/pricing"
 	"github.com/JiaCheng2004/Polaris/internal/provider"
 	"github.com/JiaCheng2004/Polaris/internal/provider/verification"
 	"github.com/JiaCheng2004/Polaris/internal/store"
@@ -113,7 +114,16 @@ func run() error {
 	for _, warning := range registryWarnings {
 		logger.Warn("registry warning", "warning", warning)
 	}
-	runtimeHolder := gwruntime.NewHolder(cfg, registry)
+
+	pricingCatalog, pricingWarnings, err := pricing.Load(cfg.Pricing.File)
+	if err != nil {
+		return fmt.Errorf("load pricing catalog: %w", err)
+	}
+	for _, warning := range pricingWarnings {
+		logger.Warn("pricing warning", "warning", warning)
+	}
+	pricingHolder := pricing.NewHolder(pricingCatalog)
+	runtimeHolder := gwruntime.NewHolderWithPricing(cfg, registry, pricingHolder)
 
 	requestLogger := store.NewAsyncRequestLogger(appStore, logger, store.NewLoggerConfig(cfg.Store.LogBufferSize, cfg.Store.LogFlushInterval))
 	defer func() {
@@ -191,6 +201,7 @@ func run() error {
 	signal.Notify(reloadSignals, syscall.SIGHUP)
 	defer signal.Stop(reloadSignals)
 	go configWatcher.Run(watcherCtx, reloadSignals)
+	go pricing.WatchFile(watcherCtx, pricingHolder, cfg.Pricing.File, time.Duration(cfg.Pricing.ReloadIntervalSeconds)*time.Second, logger)
 
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)

--- a/config/polaris.example.yaml
+++ b/config/polaris.example.yaml
@@ -93,6 +93,12 @@ runtime:
   mcp:
     enabled: true
 
+  pricing:
+    # Optional operator overrides. Bundled defaults are always loaded first.
+    file: "" # e.g. ./pricing.yaml
+    reload_interval_seconds: 30
+    fail_on_missing: false
+
   observability:
     metrics:
       enabled: true

--- a/config/security/gosec_allowlist.json
+++ b/config/security/gosec_allowlist.json
@@ -43,6 +43,13 @@
       "rationale": "Developer-only security checker reads paths only after cleanRepoPath confines them to the repository root."
     },
     {
+      "rule_id": "G304",
+      "file": "internal/pricing/loader.go",
+      "symbol": "Load",
+      "snippet": "data, err := os.ReadFile(path)",
+      "rationale": "Operator-supplied pricing override path from config; same trust model as the gateway's own config file. Loaded once at startup and on hot-reload via the file watcher."
+    },
+    {
       "rule_id": "G704",
       "file": "tests/e2e/live_smoke_harness.go",
       "symbol": "requireOllama",

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1869,6 +1869,10 @@ Return usage statistics for the authenticated key over a time range.
   "total_requests": 1423,
   "total_tokens": 892145,
   "total_cost_usd": 18.42,
+  "cost_source_breakdown": {
+    "table": 1390,
+    "missing": 33
+  },
   "by_day": [
     { "date": "2026-04-10", "requests": 62, "tokens": 41203, "cost_usd": 0.84 }
   ],
@@ -1878,7 +1882,7 @@ Return usage statistics for the authenticated key over a time range.
 
 When `group_by=model`, `by_day` is `null` and `by_model` contains an array of `{ "model": "...", "requests": N, "tokens": N, "cost_usd": N }` entries.
 
-`cost_usd` is an *estimate* computed from the cost tables in `internal/gateway/middleware/pricing.go`. It is NOT an authoritative bill. Unknown model costs default to `0` rather than blocking usage reporting.
+`cost_usd` is an *estimate* computed by the YAML-driven pricing catalog in `internal/pricing`. It is NOT an authoritative bill. Unknown model costs default to `0` rather than blocking usage reporting. `cost_source_breakdown` counts request logs by `table`, `missing`, `fallback_zero`, or `unknown` provenance.
 
 For the Phase 5A runtime, `modality=music` is supported alongside `chat`, `image`, `video`, `voice`, `audio`, and `embed`.
 

--- a/docs/PRICING.md
+++ b/docs/PRICING.md
@@ -1,0 +1,75 @@
+# Pricing
+
+Polaris estimates request cost through `internal/pricing`, a YAML-driven catalog loaded at startup and read through an atomic holder. Bundled defaults live in `internal/pricing/data/*.yaml`; operators can add or replace entries with `runtime.pricing.file`.
+
+Cost estimates are operational telemetry, not provider invoices. Missing models return `$0` with `cost_source=missing`; requests with no billable dimensions return `$0` with `cost_source=fallback_zero`.
+
+## Runtime Config
+
+```yaml
+runtime:
+  pricing:
+    file: ./pricing.yaml
+    reload_interval_seconds: 30
+    fail_on_missing: false
+```
+
+- `file`: optional override file. Bundled defaults always load first.
+- `reload_interval_seconds`: polling interval for override hot reload. `0` disables the pricing watcher.
+- `fail_on_missing`: when true, resolved models without a pricing entry return `400 model_not_priced` before the provider call. Default behavior remains graceful degradation to `$0`.
+
+Overrides replace bundled entries by exact `provider/model` key. New keys are added. Wildcards are supported as suffix matches, for example `ollama/*`.
+
+## Schema
+
+```yaml
+version: 1
+models:
+  openai/gpt-4o:
+    mode: chat
+    currency: USD
+    context_window: 128000
+    source: https://platform.openai.com/docs/pricing
+    effective_from: 2026-04-01
+    pricing:
+      input_per_mtok: 5.00
+      output_per_mtok: 15.00
+      cache_read_per_mtok: 2.50
+    tiers:
+      batch: { multiplier: 0.5 }
+      flex: { input_per_mtok: 2.50, output_per_mtok: 7.50 }
+```
+
+Supported token rates include `input_per_mtok`, `output_per_mtok`, `output_reasoning_per_mtok`, cache read/write rates, DeepSeek-style `input_cache_hit_per_mtok`, and image token rates.
+
+Supported non-token rates include `input_per_audio_second`, `input_per_video_second`, `input_per_character`, `input_per_image`, `output_per_image`, `output_per_pixel`, and `per_call`.
+
+Use `tiered_pricing` for context-length bands:
+
+```yaml
+tiered_pricing:
+  - id: lte_32k
+    range: [0, 32000]
+    input_per_mtok: 1.20
+    output_per_mtok: 6.00
+```
+
+Use `additional_units` for tool surcharges:
+
+```yaml
+additional_units:
+  web_search_per_1k_calls: 10.00
+```
+
+The estimator accepts unit counts such as `web_search: 3` and applies the matching `_per_call`, `_per_1k_calls`, or `_per_container_hour` rate.
+
+## Adding A Model
+
+Add the entry to the provider YAML in `internal/pricing/data/`, include `source` and `effective_from`, then run:
+
+```bash
+go test ./internal/pricing
+go test ./internal/gateway/middleware
+```
+
+If the API surface or usage response changes, update `docs/API_REFERENCE.md` and `spec/openapi/polaris.v1.yaml` in the same change.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	ControlPlane  ControlPlaneConfig        `yaml:"control_plane"`
 	Tools         ToolsConfig               `yaml:"tools"`
 	MCP           MCPConfig                 `yaml:"mcp"`
+	Pricing       PricingConfig             `yaml:"pricing"`
 	Observability ObservabilityConfig       `yaml:"observability"`
 }
 
@@ -205,6 +206,12 @@ type MCPConfig struct {
 	Enabled bool `yaml:"enabled"`
 }
 
+type PricingConfig struct {
+	File                  string `yaml:"file"`
+	ReloadIntervalSeconds int    `yaml:"reload_interval_seconds"`
+	FailOnMissing         bool   `yaml:"fail_on_missing"`
+}
+
 type FallbackRule struct {
 	From string   `yaml:"from"`
 	To   []string `yaml:"to"`
@@ -300,6 +307,9 @@ func Default() Config {
 			Local: map[string]LocalToolConfig{},
 		},
 		MCP: MCPConfig{},
+		Pricing: PricingConfig{
+			ReloadIntervalSeconds: 30,
+		},
 		Observability: ObservabilityConfig{
 			Metrics: MetricsConfig{
 				Enabled: true,
@@ -487,6 +497,10 @@ func ApplyRuntimeOverrides(cfg *Config, overrides RuntimeOverrides) {
 	if overrides.LogLevel != "" {
 		cfg.Observability.Logging.Level = overrides.LogLevel
 	}
+}
+
+func ExpandEnv(input string) (string, []string) {
+	return expandEnv(input)
 }
 
 func expandEnv(input string) (string, []string) {

--- a/internal/config/v2.go
+++ b/internal/config/v2.go
@@ -159,7 +159,7 @@ func normalizeV2Config(raw map[string]any) (map[string]any, error) {
 
 	normalized := map[string]any{}
 	if runtime, ok := stringMap(raw["runtime"]); ok {
-		for _, section := range []string{"server", "auth", "store", "cache", "control_plane", "tools", "mcp", "observability"} {
+		for _, section := range []string{"server", "auth", "store", "cache", "control_plane", "tools", "mcp", "pricing", "observability"} {
 			if value, exists := runtime[section]; exists {
 				normalized[section] = value
 			}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/JiaCheng2004/Polaris/internal/modality"
@@ -160,6 +161,16 @@ func Validate(cfg *Config) error {
 	}
 	if cfg.Cache.ResponseCache.SimilarityThreshold < 0 || cfg.Cache.ResponseCache.SimilarityThreshold > 1 {
 		problems = append(problems, errors.New("cache.response_cache.similarity_threshold must be between 0 and 1"))
+	}
+	if cfg.Pricing.ReloadIntervalSeconds < 0 {
+		problems = append(problems, errors.New("pricing.reload_interval_seconds must not be negative"))
+	}
+	if strings.TrimSpace(cfg.Pricing.File) != "" {
+		if info, err := os.Stat(cfg.Pricing.File); err != nil {
+			problems = append(problems, fmt.Errorf("pricing.file must be readable: %w", err))
+		} else if info.IsDir() {
+			problems = append(problems, errors.New("pricing.file must be a file, not a directory"))
+		}
 	}
 
 	for providerName, provider := range cfg.Providers {

--- a/internal/gateway/handler/audio.go
+++ b/internal/gateway/handler/audio.go
@@ -47,7 +47,7 @@ func (h *AudioHandler) Create(c *gin.Context) {
 	}
 
 	auth := middleware.GetAuthContext(c)
-	resolved, err := resolveEndpointModel(c.Request.Context(), registry, auth, req.Model, req.Routing, modality.ModalityAudio, modality.CapabilityAudioInput, modality.CapabilityAudioOutput)
+	resolved, err := resolveEndpointModel(c, registry, auth, req.Model, req.Routing, modality.ModalityAudio, modality.CapabilityAudioInput, modality.CapabilityAudioOutput)
 	if err != nil {
 		writeModalityTargetError(c, err, "audio sessions")
 		return
@@ -241,6 +241,7 @@ func (h *AudioHandler) WebSocket(c *gin.Context) {
 	outcome.PromptTokens = usage.InputTextTokens
 	outcome.CompletionTokens = usage.OutputTextTokens
 	outcome.TotalTokens = usage.TotalTokens
+	outcome.AudioSeconds = usage.InputAudioSeconds + usage.OutputAudioSeconds
 	outcome.TokenSource = countsTokenSource(usage.InputTextTokens, usage.OutputTextTokens, usage.TotalTokens)
 	middleware.SetRequestOutcome(c, outcome)
 }

--- a/internal/gateway/handler/conversation.go
+++ b/internal/gateway/handler/conversation.go
@@ -25,11 +25,11 @@ func (h *ChatHandler) prepareConversation(c *gin.Context, req *modality.ChatRequ
 		return chatTarget{}, nil, httputil.NewError(http.StatusServiceUnavailable, "provider_error", "registry_unavailable", "model", "Model registry is unavailable.")
 	}
 
-	primary, err := h.resolveChatTarget(c.Request.Context(), registry, auth, req.Model, req.Routing, requiredCapabilities)
+	primary, err := h.resolveChatTarget(c, registry, auth, req.Model, req.Routing, requiredCapabilities)
 	if err != nil {
 		return chatTarget{}, nil, err
 	}
-	fallbacks := h.resolveFallbackTargets(c.Request.Context(), registry, auth, primary.model.ID, requiredCapabilities)
+	fallbacks := h.resolveFallbackTargets(c, registry, auth, primary.model.ID, requiredCapabilities)
 	return primary, fallbacks, nil
 }
 

--- a/internal/gateway/handler/conversation_execution.go
+++ b/internal/gateway/handler/conversation_execution.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"context"
 	"net/http"
 	"time"
 
@@ -81,7 +80,8 @@ func (h *ChatHandler) completeWithFailover(c *gin.Context, primary chatTarget, f
 	return nil, lastOutcome, "", httputil.NewError(http.StatusBadGateway, "provider_error", "provider_unavailable", "model", "No available provider could serve this request.")
 }
 
-func (h *ChatHandler) resolveChatTarget(ctx context.Context, registry *provider.Registry, auth middleware.AuthContext, name string, routing *modality.RoutingOptions, requiredCapabilities []modality.Capability) (chatTarget, error) {
+func (h *ChatHandler) resolveChatTarget(c *gin.Context, registry *provider.Registry, auth middleware.AuthContext, name string, routing *modality.RoutingOptions, requiredCapabilities []modality.Capability) (chatTarget, error) {
+	ctx := c.Request.Context()
 	_, span := telemetry.StartInternalSpan(ctx, "policy.resolve_chat_target",
 		attribute.String("polaris.requested_model", name),
 		attribute.String("polaris.modality", string(modality.ModalityChat)),
@@ -113,6 +113,10 @@ func (h *ChatHandler) resolveChatTarget(ctx context.Context, registry *provider.
 		telemetry.RecordSpanError(span, err)
 		return chatTarget{}, err
 	}
+	if err := enforcePricingPolicy(c, model.ID); err != nil {
+		telemetry.RecordSpanError(span, err)
+		return chatTarget{}, err
+	}
 	span.SetAttributes(
 		attribute.String("polaris.model", model.ID),
 		attribute.String("polaris.provider", model.Provider),
@@ -120,10 +124,10 @@ func (h *ChatHandler) resolveChatTarget(ctx context.Context, registry *provider.
 	return chatTarget{adapter: adapter, model: model, resolution: resolution}, nil
 }
 
-func (h *ChatHandler) resolveFallbackTargets(ctx context.Context, registry *provider.Registry, auth middleware.AuthContext, primaryModelID string, requiredCapabilities []modality.Capability) []chatTarget {
+func (h *ChatHandler) resolveFallbackTargets(c *gin.Context, registry *provider.Registry, auth middleware.AuthContext, primaryModelID string, requiredCapabilities []modality.Capability) []chatTarget {
 	var targets []chatTarget
 	for _, candidate := range registry.GetFallbacks(primaryModelID) {
-		target, err := h.resolveChatTarget(ctx, registry, auth, candidate, nil, requiredCapabilities)
+		target, err := h.resolveChatTarget(c, registry, auth, candidate, nil, requiredCapabilities)
 		if err != nil {
 			continue
 		}

--- a/internal/gateway/handler/embed.go
+++ b/internal/gateway/handler/embed.go
@@ -40,7 +40,7 @@ func (h *EmbedHandler) Create(c *gin.Context) {
 	}
 
 	auth := middleware.GetAuthContext(c)
-	resolved, err := resolveEndpointModel(c.Request.Context(), registry, auth, req.Model, req.Routing, modality.ModalityEmbed)
+	resolved, err := resolveEndpointModel(c, registry, auth, req.Model, req.Routing, modality.ModalityEmbed)
 	if err != nil {
 		writeModalityTargetError(c, err, "embeddings")
 		return

--- a/internal/gateway/handler/image.go
+++ b/internal/gateway/handler/image.go
@@ -46,7 +46,7 @@ func (h *ImageHandler) Generate(c *gin.Context) {
 	}
 
 	auth := middleware.GetAuthContext(c)
-	resolved, err := resolveEndpointModel(c.Request.Context(), registry, auth, req.Model, req.Routing, modality.ModalityImage, required...)
+	resolved, err := resolveEndpointModel(c, registry, auth, req.Model, req.Routing, modality.ModalityImage, required...)
 	if err != nil {
 		writeModalityTargetError(c, err, "images")
 		return
@@ -80,6 +80,7 @@ func (h *ImageHandler) Generate(c *gin.Context) {
 		Provider:   model.Provider,
 		Modality:   modality.ModalityImage,
 		StatusCode: http.StatusOK,
+		Images:     imageCount(response, req.N),
 	})
 	if cacheCtl != nil {
 		cacheCtl.storeJSON(c, cacheKey, http.StatusOK, response)
@@ -105,7 +106,7 @@ func (h *ImageHandler) Edit(c *gin.Context) {
 	}
 
 	auth := middleware.GetAuthContext(c)
-	resolved, err := resolveEndpointModel(c.Request.Context(), registry, auth, req.Model, req.Routing, modality.ModalityImage, modality.CapabilityEditing)
+	resolved, err := resolveEndpointModel(c, registry, auth, req.Model, req.Routing, modality.ModalityImage, modality.CapabilityEditing)
 	if err != nil {
 		writeModalityTargetError(c, err, "images")
 		return
@@ -146,6 +147,7 @@ func (h *ImageHandler) Edit(c *gin.Context) {
 		Provider:   model.Provider,
 		Modality:   modality.ModalityImage,
 		StatusCode: http.StatusOK,
+		Images:     imageCount(response, req.N),
 	})
 	if cacheCtl != nil {
 		cacheCtl.storeJSON(c, cacheKey, http.StatusOK, response)
@@ -159,6 +161,16 @@ func (h *ImageHandler) registry(c *gin.Context) *provider.Registry {
 		return nil
 	}
 	return snapshot.Registry
+}
+
+func imageCount(response *modality.ImageResponse, fallback int) int {
+	if response != nil && len(response.Data) > 0 {
+		return len(response.Data)
+	}
+	if fallback > 0 {
+		return fallback
+	}
+	return 1
 }
 
 func parseImageEditRequest(c *gin.Context) (*modality.ImageEditRequest, error) {

--- a/internal/gateway/handler/interpreting.go
+++ b/internal/gateway/handler/interpreting.go
@@ -43,7 +43,7 @@ func (h *InterpretingHandler) Create(c *gin.Context) {
 	}
 
 	auth := middleware.GetAuthContext(c)
-	resolved, err := resolveEndpointModel(c.Request.Context(), registry, auth, req.Model, req.Routing, modality.ModalityInterpreting, modality.CapabilityAudioInput)
+	resolved, err := resolveEndpointModel(c, registry, auth, req.Model, req.Routing, modality.ModalityInterpreting, modality.CapabilityAudioInput)
 	if err != nil {
 		writeModalityTargetError(c, err, "interpreting sessions")
 		return

--- a/internal/gateway/handler/multimodal_helpers.go
+++ b/internal/gateway/handler/multimodal_helpers.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -20,7 +19,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
-func resolveEndpointModel(ctx context.Context, registry *provider.Registry, auth middleware.AuthContext, name string, routing *modality.RoutingOptions, requiredModality modality.Modality, requiredCapabilities ...modality.Capability) (provider.Resolution, error) {
+func resolveEndpointModel(c *gin.Context, registry *provider.Registry, auth middleware.AuthContext, name string, routing *modality.RoutingOptions, requiredModality modality.Modality, requiredCapabilities ...modality.Capability) (provider.Resolution, error) {
+	ctx := c.Request.Context()
 	_, span := telemetry.StartInternalSpan(ctx, "policy.resolve_model",
 		attribute.String("polaris.requested_model", name),
 		attribute.String("polaris.modality", string(requiredModality)),
@@ -48,11 +48,33 @@ func resolveEndpointModel(ctx context.Context, registry *provider.Registry, auth
 		telemetry.RecordSpanError(span, err)
 		return provider.Resolution{}, err
 	}
+	if err := enforcePricingPolicy(c, model.ID); err != nil {
+		telemetry.RecordSpanError(span, err)
+		return provider.Resolution{}, err
+	}
 	span.SetAttributes(
 		attribute.String("polaris.model", model.ID),
 		attribute.String("polaris.provider", model.Provider),
 	)
 	return resolution, nil
+}
+
+// enforcePricingPolicy is invoked from resolveEndpointModel above and from
+// conversation_execution.go (the chat path that does not flow through
+// resolveEndpointModel). Every other model-resolving entrypoint routes
+// through resolveEndpointModel, so those two call sites cover the gateway.
+func enforcePricingPolicy(c *gin.Context, modelID string) error {
+	snapshot, ok := middleware.GetRuntimeSnapshot(c)
+	if !ok || snapshot == nil || snapshot.Config == nil || !snapshot.Config.Pricing.FailOnMissing {
+		return nil
+	}
+	if snapshot.Pricing == nil {
+		return httputil.NewError(http.StatusBadRequest, "model_not_priced", "pricing_unavailable", "model", "Pricing catalog is unavailable.")
+	}
+	if _, ok := snapshot.Pricing.Lookup(modelID); !ok {
+		return httputil.NewError(http.StatusBadRequest, "model_not_priced", "model_not_priced", "model", "Requested model does not have a pricing entry.")
+	}
+	return nil
 }
 
 func writeModalityTargetError(c *gin.Context, err error, endpointName string) {

--- a/internal/gateway/handler/music.go
+++ b/internal/gateway/handler/music.go
@@ -98,7 +98,7 @@ func (h *MusicHandler) Generate(c *gin.Context) {
 	if env.Instrumental {
 		required = append(required, modality.CapabilityInstrumental)
 	}
-	resolved, err := resolveEndpointModel(c.Request.Context(), registry, auth, env.Model, env.Routing, modality.ModalityMusic, required...)
+	resolved, err := resolveEndpointModel(c, registry, auth, env.Model, env.Routing, modality.ModalityMusic, required...)
 	if err != nil {
 		writeModalityTargetError(c, err, "music")
 		return
@@ -149,7 +149,7 @@ func (h *MusicHandler) Edit(c *gin.Context) {
 
 	auth := middleware.GetAuthContext(c)
 	required := requiredMusicEditCapabilities(env)
-	resolved, err := resolveEndpointModel(c.Request.Context(), registry, auth, env.Model, env.Routing, modality.ModalityMusic, required...)
+	resolved, err := resolveEndpointModel(c, registry, auth, env.Model, env.Routing, modality.ModalityMusic, required...)
 	if err != nil {
 		writeModalityTargetError(c, err, "music edits")
 		return
@@ -203,7 +203,7 @@ func (h *MusicHandler) Stems(c *gin.Context) {
 	}
 
 	auth := middleware.GetAuthContext(c)
-	resolved, err := resolveEndpointModel(c.Request.Context(), registry, auth, env.Model, env.Routing, modality.ModalityMusic, modality.CapabilityMusicStems)
+	resolved, err := resolveEndpointModel(c, registry, auth, env.Model, env.Routing, modality.ModalityMusic, modality.CapabilityMusicStems)
 	if err != nil {
 		writeModalityTargetError(c, err, "music stems")
 		return
@@ -255,7 +255,7 @@ func (h *MusicHandler) Lyrics(c *gin.Context) {
 	}
 
 	auth := middleware.GetAuthContext(c)
-	resolved, err := resolveEndpointModel(c.Request.Context(), registry, auth, req.Model, req.Routing, modality.ModalityMusic, modality.CapabilityLyricsGeneration)
+	resolved, err := resolveEndpointModel(c, registry, auth, req.Model, req.Routing, modality.ModalityMusic, modality.CapabilityLyricsGeneration)
 	if err != nil {
 		writeModalityTargetError(c, err, "music lyrics")
 		return
@@ -314,7 +314,7 @@ func (h *MusicHandler) Plans(c *gin.Context) {
 	}
 
 	auth := middleware.GetAuthContext(c)
-	resolved, err := resolveEndpointModel(c.Request.Context(), registry, auth, req.Model, req.Routing, modality.ModalityMusic, modality.CapabilityCompositionPlans)
+	resolved, err := resolveEndpointModel(c, registry, auth, req.Model, req.Routing, modality.ModalityMusic, modality.CapabilityCompositionPlans)
 	if err != nil {
 		writeModalityTargetError(c, err, "music plans")
 		return
@@ -759,7 +759,7 @@ func (h *MusicHandler) resolveAuthorizedJobRecord(c *gin.Context) (musicJobRecor
 	if auth.KeyID != token.KeyID {
 		return musicJobRecord{}, nil, httputil.NewError(http.StatusForbidden, "permission_error", "job_not_owned", "id", "Music job was created by a different API key.")
 	}
-	resolved, err := resolveEndpointModel(c.Request.Context(), registry, auth, token.Model, nil, modality.ModalityMusic)
+	resolved, err := resolveEndpointModel(c, registry, auth, token.Model, nil, modality.ModalityMusic)
 	if err != nil {
 		return musicJobRecord{}, nil, err
 	}

--- a/internal/gateway/handler/notes.go
+++ b/internal/gateway/handler/notes.go
@@ -39,7 +39,7 @@ func (h *NotesHandler) Create(c *gin.Context) {
 		return
 	}
 	auth := middleware.GetAuthContext(c)
-	resolved, err := resolveEndpointModel(c.Request.Context(), registry, auth, req.Model, req.Routing, modality.ModalityNotes, modality.CapabilityAudioNotes)
+	resolved, err := resolveEndpointModel(c, registry, auth, req.Model, req.Routing, modality.ModalityNotes, modality.CapabilityAudioNotes)
 	if err != nil {
 		writeModalityTargetError(c, err, "audio notes")
 		return
@@ -143,7 +143,7 @@ func (h *NotesHandler) resolveAuthorizedNote(c *gin.Context, registry *provider.
 	if token.KeyID != "" && auth.KeyID != "" && token.KeyID != auth.KeyID {
 		return audioNoteToken{}, provider.Model{}, nil, invalidAudioNoteIDError()
 	}
-	resolved, err := resolveEndpointModel(c.Request.Context(), registry, auth, token.Model, nil, modality.ModalityNotes, modality.CapabilityAudioNotes)
+	resolved, err := resolveEndpointModel(c, registry, auth, token.Model, nil, modality.ModalityNotes, modality.CapabilityAudioNotes)
 	if err != nil {
 		return audioNoteToken{}, provider.Model{}, nil, translateNoteTargetError(err)
 	}

--- a/internal/gateway/handler/podcast.go
+++ b/internal/gateway/handler/podcast.go
@@ -66,7 +66,7 @@ func (h *PodcastHandler) Create(c *gin.Context) {
 		return
 	}
 	auth := middleware.GetAuthContext(c)
-	resolved, err := resolveEndpointModel(c.Request.Context(), registry, auth, req.Model, req.Routing, modality.ModalityPodcast, modality.CapabilityPodcastGeneration)
+	resolved, err := resolveEndpointModel(c, registry, auth, req.Model, req.Routing, modality.ModalityPodcast, modality.CapabilityPodcastGeneration)
 	if err != nil {
 		writeModalityTargetError(c, err, "audio podcasts")
 		return
@@ -250,7 +250,7 @@ func (h *PodcastHandler) resolveAuthorizedPodcast(c *gin.Context) (podcastJobRec
 	if token.KeyID != "" && auth.KeyID != "" && token.KeyID != auth.KeyID {
 		return podcastJobRecord{}, nil, invalidPodcastJobIDError()
 	}
-	if _, err := resolveEndpointModel(c.Request.Context(), registry, auth, token.Model, nil, modality.ModalityPodcast, modality.CapabilityPodcastGeneration); err != nil {
+	if _, err := resolveEndpointModel(c, registry, auth, token.Model, nil, modality.ModalityPodcast, modality.CapabilityPodcastGeneration); err != nil {
 		return podcastJobRecord{}, nil, translatePodcastTargetError(err)
 	}
 	record, err := h.getPodcastJob(c.Request.Context(), token.CacheKey)

--- a/internal/gateway/handler/translation.go
+++ b/internal/gateway/handler/translation.go
@@ -38,7 +38,7 @@ func (h *TranslationHandler) Translate(c *gin.Context) {
 	}
 
 	auth := middleware.GetAuthContext(c)
-	resolved, err := resolveEndpointModel(c.Request.Context(), registry, auth, req.Model, req.Routing, modality.ModalityTranslation)
+	resolved, err := resolveEndpointModel(c, registry, auth, req.Model, req.Routing, modality.ModalityTranslation)
 	if err != nil {
 		writeModalityTargetError(c, err, "translations")
 		return

--- a/internal/gateway/handler/usage.go
+++ b/internal/gateway/handler/usage.go
@@ -78,12 +78,13 @@ func (h *UsageHandler) Get(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"from":           from.Format(time.RFC3339),
-		"to":             to.Format(time.RFC3339),
-		"total_requests": report.TotalRequests,
-		"total_tokens":   report.TotalTokens,
-		"total_cost_usd": report.TotalCost,
-		"by_day":         report.ByDay,
-		"by_model":       report.ByModel,
+		"from":                  from.Format(time.RFC3339),
+		"to":                    to.Format(time.RFC3339),
+		"total_requests":        report.TotalRequests,
+		"total_tokens":          report.TotalTokens,
+		"total_cost_usd":        report.TotalCost,
+		"cost_source_breakdown": report.CostSourceBreakdown,
+		"by_day":                report.ByDay,
+		"by_model":              report.ByModel,
 	})
 }

--- a/internal/gateway/handler/video.go
+++ b/internal/gateway/handler/video.go
@@ -65,7 +65,7 @@ func (h *VideoHandler) Generate(c *gin.Context) {
 	}
 
 	auth := middleware.GetAuthContext(c)
-	resolved, err := resolveEndpointModel(c.Request.Context(), registry, auth, req.Model, req.Routing, modality.ModalityVideo, required...)
+	resolved, err := resolveEndpointModel(c, registry, auth, req.Model, req.Routing, modality.ModalityVideo, required...)
 	if err != nil {
 		writeModalityTargetError(c, err, "video")
 		return
@@ -108,10 +108,11 @@ func (h *VideoHandler) Generate(c *gin.Context) {
 	}
 
 	middleware.SetRequestOutcome(c, middleware.RequestOutcome{
-		Model:      model.ID,
-		Provider:   model.Provider,
-		Modality:   modality.ModalityVideo,
-		StatusCode: http.StatusOK,
+		Model:        model.ID,
+		Provider:     model.Provider,
+		Modality:     modality.ModalityVideo,
+		StatusCode:   http.StatusOK,
+		VideoSeconds: float64(req.Duration),
 	})
 	c.JSON(http.StatusOK, job)
 }
@@ -288,7 +289,7 @@ func (h *VideoHandler) resolveAuthorizedJob(c *gin.Context) (*videoJobToken, pro
 		return nil, provider.Model{}, nil, httputil.NewError(http.StatusForbidden, "permission_error", "job_not_owned", "id", "Video job was created by a different API key.")
 	}
 
-	resolved, err := resolveEndpointModel(c.Request.Context(), registry, auth, jobToken.Model, nil, modality.ModalityVideo)
+	resolved, err := resolveEndpointModel(c, registry, auth, jobToken.Model, nil, modality.ModalityVideo)
 	if err != nil {
 		writeModalityTargetError(c, err, "video")
 		return nil, provider.Model{}, nil, errVideoResponseWritten

--- a/internal/gateway/handler/voice.go
+++ b/internal/gateway/handler/voice.go
@@ -41,7 +41,7 @@ func (h *VoiceHandler) Speech(c *gin.Context) {
 	}
 
 	auth := middleware.GetAuthContext(c)
-	resolved, err := resolveEndpointModel(c.Request.Context(), registry, auth, req.Model, req.Routing, modality.ModalityVoice, modality.CapabilityTTS)
+	resolved, err := resolveEndpointModel(c, registry, auth, req.Model, req.Routing, modality.ModalityVoice, modality.CapabilityTTS)
 	if err != nil {
 		writeModalityTargetError(c, err, "audio speech")
 		return
@@ -79,6 +79,7 @@ func (h *VoiceHandler) Speech(c *gin.Context) {
 		Provider:   model.Provider,
 		Modality:   modality.ModalityVoice,
 		StatusCode: http.StatusOK,
+		Characters: len([]rune(req.Input)),
 	})
 	if cacheCtl != nil && response != nil {
 		cacheCtl.storeRaw(c, cacheKey, http.StatusOK, response.ContentType, response.Data)
@@ -104,7 +105,7 @@ func (h *VoiceHandler) Transcribe(c *gin.Context) {
 	}
 
 	auth := middleware.GetAuthContext(c)
-	resolved, err := resolveEndpointModel(c.Request.Context(), registry, auth, req.Model, req.Routing, modality.ModalityVoice, modality.CapabilitySTT)
+	resolved, err := resolveEndpointModel(c, registry, auth, req.Model, req.Routing, modality.ModalityVoice, modality.CapabilitySTT)
 	if err != nil {
 		writeModalityTargetError(c, err, "audio transcription")
 		return
@@ -146,10 +147,11 @@ func (h *VoiceHandler) Transcribe(c *gin.Context) {
 		return
 	}
 	middleware.SetRequestOutcome(c, middleware.RequestOutcome{
-		Model:      model.ID,
-		Provider:   model.Provider,
-		Modality:   modality.ModalityVoice,
-		StatusCode: http.StatusOK,
+		Model:        model.ID,
+		Provider:     model.Provider,
+		Modality:     modality.ModalityVoice,
+		StatusCode:   http.StatusOK,
+		AudioSeconds: transcriptDuration(response),
 	})
 	if cacheCtl != nil && response != nil {
 		if req.ResponseFormat == "json" {
@@ -171,6 +173,13 @@ func (h *VoiceHandler) registry(c *gin.Context) *provider.Registry {
 		return nil
 	}
 	return snapshot.Registry
+}
+
+func transcriptDuration(response *modality.TranscriptResponse) float64 {
+	if response == nil || response.Duration <= 0 {
+		return 0
+	}
+	return response.Duration
 }
 
 func parseSTTRequest(c *gin.Context) (*modality.STTRequest, error) {

--- a/internal/gateway/handler/voice_stream.go
+++ b/internal/gateway/handler/voice_stream.go
@@ -33,7 +33,7 @@ func (h *VoiceHandler) CreateStreamingTranscriptionSession(c *gin.Context) {
 	}
 
 	auth := middleware.GetAuthContext(c)
-	resolved, err := resolveEndpointModel(c.Request.Context(), registry, auth, req.Model, req.Routing, modality.ModalityVoice, modality.CapabilityStreaming)
+	resolved, err := resolveEndpointModel(c, registry, auth, req.Model, req.Routing, modality.ModalityVoice, modality.CapabilityStreaming)
 	if err != nil {
 		writeModalityTargetError(c, err, "streaming transcription")
 		return

--- a/internal/gateway/handler/voices.go
+++ b/internal/gateway/handler/voices.go
@@ -165,7 +165,7 @@ func (h *VoicesHandler) CreateClone(c *gin.Context) {
 		return
 	}
 	auth := middleware.GetAuthContext(c)
-	resolved, err := resolveEndpointModel(c.Request.Context(), registry, auth, req.Model, req.Routing, modality.ModalityVoice, modality.CapabilityVoiceCloning)
+	resolved, err := resolveEndpointModel(c, registry, auth, req.Model, req.Routing, modality.ModalityVoice, modality.CapabilityVoiceCloning)
 	if err != nil {
 		writeModalityTargetError(c, err, "voice cloning")
 		return
@@ -209,7 +209,7 @@ func (h *VoicesHandler) CreateDesign(c *gin.Context) {
 		return
 	}
 	auth := middleware.GetAuthContext(c)
-	resolved, err := resolveEndpointModel(c.Request.Context(), registry, auth, req.Model, req.Routing, modality.ModalityVoice, modality.CapabilityVoiceDesign)
+	resolved, err := resolveEndpointModel(c, registry, auth, req.Model, req.Routing, modality.ModalityVoice, modality.CapabilityVoiceDesign)
 	if err != nil {
 		writeModalityTargetError(c, err, "voice design")
 		return
@@ -258,7 +258,7 @@ func (h *VoicesHandler) Retrain(c *gin.Context) {
 		return
 	}
 	auth := middleware.GetAuthContext(c)
-	resolved, err := resolveEndpointModel(c.Request.Context(), registry, auth, req.Model, req.Routing, modality.ModalityVoice, modality.CapabilityVoiceCloning)
+	resolved, err := resolveEndpointModel(c, registry, auth, req.Model, req.Routing, modality.ModalityVoice, modality.CapabilityVoiceCloning)
 	if err != nil {
 		writeModalityTargetError(c, err, "voice retraining")
 		return
@@ -478,7 +478,7 @@ func (h *VoicesHandler) resolveVoiceProvider(c *gin.Context, providerName string
 	modelName = strings.TrimSpace(modelName)
 	if modelName != "" {
 		auth := middleware.GetAuthContext(c)
-		resolved, err := resolveEndpointModel(c.Request.Context(), registry, auth, modelName, nil, modality.ModalityVoice)
+		resolved, err := resolveEndpointModel(c, registry, auth, modelName, nil, modality.ModalityVoice)
 		if err != nil {
 			return resolvedVoiceProvider{}, translateVoiceTargetError(err)
 		}

--- a/internal/gateway/metrics/metrics.go
+++ b/internal/gateway/metrics/metrics.go
@@ -17,6 +17,7 @@ type Recorder struct {
 	providerLatency *prometheus.HistogramVec
 	tokensTotal     *prometheus.CounterVec
 	estimatedCost   *prometheus.CounterVec
+	pricingLookups  *prometheus.CounterVec
 	rateLimitHits   *prometheus.CounterVec
 	budgetDenials   *prometheus.CounterVec
 	providerErrors  *prometheus.CounterVec
@@ -53,7 +54,11 @@ func NewRecorder() *Recorder {
 		estimatedCost: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "polaris_estimated_cost_usd",
 			Help: "Estimated cost in USD.",
-		}, []string{"model", "provider"}),
+		}, []string{"model", "provider", "cost_source"}),
+		pricingLookups: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "polaris_pricing_lookups_total",
+			Help: "Pricing catalog lookups by model and lookup status.",
+		}, []string{"model", "status"}),
 		rateLimitHits: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "polaris_rate_limit_hits_total",
 			Help: "Total rate-limit rejections by key.",
@@ -94,6 +99,7 @@ func NewRecorder() *Recorder {
 		recorder.providerLatency,
 		recorder.tokensTotal,
 		recorder.estimatedCost,
+		recorder.pricingLookups,
 		recorder.rateLimitHits,
 		recorder.budgetDenials,
 		recorder.providerErrors,
@@ -114,7 +120,7 @@ func (r *Recorder) Handler() http.Handler {
 	return promhttp.HandlerFor(r.registry, promhttp.HandlerOpts{})
 }
 
-func (r *Recorder) ObserveRequest(interfaceFamily string, model string, modality string, provider string, statusCode int, totalLatency time.Duration, providerLatencyMs int, promptTokens int, completionTokens int, tokenSource string, estimatedCost float64, errorType string) {
+func (r *Recorder) ObserveRequest(interfaceFamily string, model string, modality string, provider string, statusCode int, totalLatency time.Duration, providerLatencyMs int, promptTokens int, completionTokens int, tokenSource string, estimatedCost float64, costSource string, errorType string) {
 	if r == nil {
 		return
 	}
@@ -136,8 +142,21 @@ func (r *Recorder) ObserveRequest(interfaceFamily string, model string, modality
 		r.tokensTotal.WithLabelValues(model, provider, "output", tokenSource).Add(float64(completionTokens))
 	}
 	if estimatedCost > 0 {
-		r.estimatedCost.WithLabelValues(model, provider).Add(estimatedCost)
+		if costSource == "" {
+			costSource = "unknown"
+		}
+		r.estimatedCost.WithLabelValues(model, provider, costSource).Add(estimatedCost)
 	}
+}
+
+func (r *Recorder) IncPricingLookup(model string, status string) {
+	if r == nil || model == "" {
+		return
+	}
+	if status == "" {
+		status = "unknown"
+	}
+	r.pricingLookups.WithLabelValues(model, status).Inc()
 }
 
 func (r *Recorder) IncRateLimit(keyID string) {

--- a/internal/gateway/middleware/context.go
+++ b/internal/gateway/middleware/context.go
@@ -35,22 +35,35 @@ type AuthContext struct {
 }
 
 type RequestOutcome struct {
-	Model             string
-	Provider          string
-	Modality          modality.Modality
-	InterfaceFamily   string
-	TokenSource       modality.TokenCountSource
-	CacheStatus       string
-	FallbackModel     string
-	Toolset           string
-	MCPBinding        string
-	StatusCode        int
-	ErrorType         string
-	ProviderLatencyMs int
-	TotalLatencyMs    int
-	PromptTokens      int
-	CompletionTokens  int
-	TotalTokens       int
+	Model              string
+	Provider           string
+	Modality           modality.Modality
+	InterfaceFamily    string
+	TokenSource        modality.TokenCountSource
+	CacheStatus        string
+	FallbackModel      string
+	Toolset            string
+	MCPBinding         string
+	StatusCode         int
+	ErrorType          string
+	ProviderLatencyMs  int
+	TotalLatencyMs     int
+	PromptTokens       int
+	CompletionTokens   int
+	TotalTokens        int
+	Tier               string
+	Deployment         string
+	CachedInputTokens  int
+	CacheWrite5mTokens int
+	CacheWrite1hTokens int
+	ReasoningTokens    int
+	InputImageTokens   int
+	OutputImageTokens  int
+	AudioSeconds       float64
+	VideoSeconds       float64
+	Characters         int
+	Images             int
+	UnitCounts         map[string]int
 }
 
 func SetAuthContext(c *gin.Context, auth AuthContext) {

--- a/internal/gateway/middleware/metrics.go
+++ b/internal/gateway/middleware/metrics.go
@@ -25,7 +25,7 @@ func Metrics(recorder *metrics.Recorder) gin.HandlerFunc {
 		if outcome.StatusCode != 0 {
 			statusCode = outcome.StatusCode
 		}
-		cost := EstimateCostUSD(model, outcome.PromptTokens, outcome.CompletionTokens)
+		cost := estimateOutcomeCost(c, outcome, nil)
 		interfaceFamily := firstNonEmpty(outcome.InterfaceFamily, interfaceFamilyFromPath(c.FullPath()))
 		tokenSource := usageTokenSource(outcome)
 
@@ -40,9 +40,11 @@ func Metrics(recorder *metrics.Recorder) gin.HandlerFunc {
 			outcome.PromptTokens,
 			outcome.CompletionTokens,
 			tokenSource,
-			cost,
+			cost.TotalUSD,
+			cost.Source,
 			outcome.ErrorType,
 		)
+		recorder.IncPricingLookup(model, cost.LookupStatus)
 		if cacheStatus := strings.TrimSpace(c.Writer.Header().Get("X-Polaris-Cache")); cacheStatus != "" {
 			recorder.IncCacheEvent(cacheStatus, model)
 		}

--- a/internal/gateway/middleware/pricing.go
+++ b/internal/gateway/middleware/pricing.go
@@ -1,27 +1,68 @@
 package middleware
 
-type pricing struct {
-	inputPerMillion  float64
-	outputPerMillion float64
-}
+import (
+	"log/slog"
+	"strings"
+	"sync"
 
-var knownPricing = map[string]pricing{
-	"openai/gpt-4o":      {inputPerMillion: 5.00, outputPerMillion: 15.00},
-	"openai/gpt-4o-mini": {inputPerMillion: 0.15, outputPerMillion: 0.60},
-	"openai/text-embedding-3-small": {
-		inputPerMillion: 0.02,
-	},
-	"openai/text-embedding-3-large": {
-		inputPerMillion: 0.13,
-	},
-	"anthropic/claude-sonnet-4-6": {inputPerMillion: 3.00, outputPerMillion: 15.00},
-	"anthropic/claude-opus-4-6":   {inputPerMillion: 15.00, outputPerMillion: 75.00},
-}
+	pricingpkg "github.com/JiaCheng2004/Polaris/internal/pricing"
+	"github.com/gin-gonic/gin"
+)
+
+var missingPricingLogged sync.Map
 
 func EstimateCostUSD(model string, promptTokens int, completionTokens int) float64 {
-	price, ok := knownPricing[model]
-	if !ok {
-		return 0
+	result := pricingpkg.DefaultEstimator().Estimate(pricingpkg.EstimateRequest{
+		Model:        model,
+		InputTokens:  promptTokens,
+		OutputTokens: completionTokens,
+	})
+	return result.TotalUSD
+}
+
+func estimateOutcomeCost(c *gin.Context, outcome RequestOutcome, logger *slog.Logger) pricingpkg.EstimateResult {
+	estimator := pricingpkg.DefaultEstimator()
+	if snapshot, ok := GetRuntimeSnapshot(c); ok && snapshot != nil && snapshot.Pricing != nil {
+		estimator = snapshot.Pricing
 	}
-	return (float64(promptTokens)*price.inputPerMillion + float64(completionTokens)*price.outputPerMillion) / 1_000_000
+	result := estimator.Estimate(pricingRequestFromOutcome(outcome))
+	if result.Source == pricingpkg.SourceMissing {
+		logMissingPricingOnce(logger, outcome.Model)
+	}
+	return result
+}
+
+func pricingRequestFromOutcome(outcome RequestOutcome) pricingpkg.EstimateRequest {
+	return pricingpkg.EstimateRequest{
+		Model:              outcome.Model,
+		Tier:               outcome.Tier,
+		Deployment:         outcome.Deployment,
+		InputTokens:        outcome.PromptTokens,
+		CachedInputTokens:  outcome.CachedInputTokens,
+		CacheWrite5mTokens: outcome.CacheWrite5mTokens,
+		CacheWrite1hTokens: outcome.CacheWrite1hTokens,
+		OutputTokens:       outcome.CompletionTokens,
+		ReasoningTokens:    outcome.ReasoningTokens,
+		InputImageTokens:   outcome.InputImageTokens,
+		OutputImageTokens:  outcome.OutputImageTokens,
+		AudioSeconds:       outcome.AudioSeconds,
+		VideoSeconds:       outcome.VideoSeconds,
+		Characters:         outcome.Characters,
+		Images:             outcome.Images,
+		UnitCounts:         outcome.UnitCounts,
+	}
+}
+
+func logMissingPricingOnce(logger *slog.Logger, model string) {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if _, loaded := missingPricingLogged.LoadOrStore(model, struct{}{}); loaded {
+		return
+	}
+	logger.Warn("missing pricing entry; estimated cost defaults to zero", "model", model)
 }

--- a/internal/gateway/middleware/pricing_test.go
+++ b/internal/gateway/middleware/pricing_test.go
@@ -18,17 +18,28 @@ func TestEstimateCostUSDEmbeddingModel(t *testing.T) {
 	}
 }
 
-func TestEstimateCostUSDUnknownPhase3ModelsDefaultToZero(t *testing.T) {
-	cases := []string{
-		"google/gemini-embedding-001",
-		"openai/gpt-image-1",
-		"openai/tts-1",
-		"bytedance/doubao-asr-2.0",
+func TestEstimateCostUSDOriginalHardcodedModelsRemainCompatible(t *testing.T) {
+	cases := []struct {
+		model      string
+		prompt     int
+		completion int
+		want       float64
+	}{
+		{"openai/gpt-4o-mini", 1000, 500, 0.00045},
+		{"openai/text-embedding-3-large", 1000, 0, 0.00013},
+		{"anthropic/claude-sonnet-4-6", 1000, 500, 0.0105},
+		{"anthropic/claude-opus-4-6", 1000, 500, 0.0525},
 	}
 
-	for _, model := range cases {
-		if got := EstimateCostUSD(model, 100, 50); got != 0 {
-			t.Fatalf("expected zero cost for %s, got %.8f", model, got)
+	for _, tc := range cases {
+		if got := EstimateCostUSD(tc.model, tc.prompt, tc.completion); got != tc.want {
+			t.Fatalf("expected %.8f for %s, got %.8f", tc.want, tc.model, got)
 		}
+	}
+}
+
+func TestEstimateCostUSDUnknownModelDefaultsToZero(t *testing.T) {
+	if got := EstimateCostUSD("unknown/model", 100, 50); got != 0 {
+		t.Fatalf("expected zero cost for unknown model, got %.8f", got)
 	}
 }

--- a/internal/gateway/middleware/usage.go
+++ b/internal/gateway/middleware/usage.go
@@ -37,6 +37,7 @@ func Usage(requestLogger *store.AsyncRequestLogger, logger *slog.Logger) gin.Han
 		if outcome.TotalTokens == 0 {
 			outcome.TotalTokens = outcome.PromptTokens + outcome.CompletionTokens
 		}
+		cost := estimateOutcomeCost(c, outcome, logger)
 
 		entry := store.RequestLog{
 			RequestID:         GetRequestID(c),
@@ -56,7 +57,8 @@ func Usage(requestLogger *store.AsyncRequestLogger, logger *slog.Logger) gin.Han
 			InputTokens:       outcome.PromptTokens,
 			OutputTokens:      outcome.CompletionTokens,
 			TotalTokens:       outcome.TotalTokens,
-			EstimatedCost:     EstimateCostUSD(outcome.Model, outcome.PromptTokens, outcome.CompletionTokens),
+			EstimatedCost:     cost.TotalUSD,
+			CostSource:        cost.Source,
 			StatusCode:        outcome.StatusCode,
 			ErrorType:         outcome.ErrorType,
 			CreatedAt:         time.Now().UTC(),

--- a/internal/gateway/phase3_usage_test.go
+++ b/internal/gateway/phase3_usage_test.go
@@ -143,9 +143,10 @@ func TestPhase3UsageAggregatesMixedModalities(t *testing.T) {
 	}
 
 	var usage struct {
-		TotalRequests int64 `json:"total_requests"`
-		TotalTokens   int64 `json:"total_tokens"`
-		ByModel       []struct {
+		TotalRequests       int64            `json:"total_requests"`
+		TotalTokens         int64            `json:"total_tokens"`
+		CostSourceBreakdown map[string]int64 `json:"cost_source_breakdown"`
+		ByModel             []struct {
 			Model   string  `json:"model"`
 			CostUSD float64 `json:"cost_usd"`
 		} `json:"by_model"`
@@ -170,10 +171,13 @@ func TestPhase3UsageAggregatesMixedModalities(t *testing.T) {
 	if byModel["openai/text-embedding-3-small"] <= 0 {
 		t.Fatalf("expected positive embedding cost, got %#v", usage.ByModel)
 	}
-	if byModel["openai/gpt-image-1"] != 0 {
-		t.Fatalf("expected zero image cost until pricing policy exists, got %#v", usage.ByModel)
+	if byModel["openai/gpt-image-1"] <= 0 {
+		t.Fatalf("expected positive image cost, got %#v", usage.ByModel)
 	}
-	if byModel["openai/tts-1"] != 0 {
-		t.Fatalf("expected zero voice cost until pricing policy exists, got %#v", usage.ByModel)
+	if byModel["openai/tts-1"] <= 0 {
+		t.Fatalf("expected positive voice cost, got %#v", usage.ByModel)
+	}
+	if usage.CostSourceBreakdown["table"] != 3 {
+		t.Fatalf("expected table cost source for all requests, got %#v", usage.CostSourceBreakdown)
 	}
 }

--- a/internal/gateway/runtime/holder.go
+++ b/internal/gateway/runtime/holder.go
@@ -4,21 +4,32 @@ import (
 	"sync/atomic"
 
 	"github.com/JiaCheng2004/Polaris/internal/config"
+	"github.com/JiaCheng2004/Polaris/internal/pricing"
 	"github.com/JiaCheng2004/Polaris/internal/provider"
 )
 
 type Snapshot struct {
 	Config     *config.Config
 	Registry   *provider.Registry
+	Pricing    pricing.Estimator
 	StaticKeys map[string]config.StaticKeyConfig
 }
 
 type Holder struct {
 	current atomic.Pointer[Snapshot]
+	pricing pricing.Estimator
 }
 
 func NewHolder(cfg *config.Config, registry *provider.Registry) *Holder {
+	return NewHolderWithPricing(cfg, registry, pricing.DefaultEstimator())
+}
+
+func NewHolderWithPricing(cfg *config.Config, registry *provider.Registry, estimator pricing.Estimator) *Holder {
 	holder := &Holder{}
+	if estimator == nil {
+		estimator = pricing.DefaultEstimator()
+	}
+	holder.pricing = estimator
 	holder.Swap(cfg, registry)
 	return holder
 }
@@ -30,6 +41,14 @@ func (h *Holder) Current() *Snapshot {
 	return h.current.Load()
 }
 
+func (h *Holder) PricingHolder() *pricing.Holder {
+	if h == nil {
+		return nil
+	}
+	holder, _ := h.pricing.(*pricing.Holder)
+	return holder
+}
+
 func (h *Holder) Swap(cfg *config.Config, registry *provider.Registry) *Snapshot {
 	if h == nil {
 		return nil
@@ -38,6 +57,7 @@ func (h *Holder) Swap(cfg *config.Config, registry *provider.Registry) *Snapshot
 	snapshot := &Snapshot{
 		Config:     cfg,
 		Registry:   registry,
+		Pricing:    h.pricing,
 		StaticKeys: compileStaticKeys(cfg),
 	}
 	h.current.Store(snapshot)

--- a/internal/gateway/runtime/reloader.go
+++ b/internal/gateway/runtime/reloader.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/JiaCheng2004/Polaris/internal/config"
+	"github.com/JiaCheng2004/Polaris/internal/pricing"
 	"github.com/JiaCheng2004/Polaris/internal/provider"
 )
 
@@ -63,6 +64,16 @@ func (r *Reloader) Reload() error {
 	}
 	for _, warning := range registryWarnings {
 		r.logger.Warn("registry warning", "warning", warning)
+	}
+	if pricingHolder := r.holder.PricingHolder(); pricingHolder != nil {
+		pricingCatalog, pricingWarnings, err := pricing.Load(nextCfg.Pricing.File)
+		if err != nil {
+			return err
+		}
+		for _, warning := range pricingWarnings {
+			r.logger.Warn("pricing warning", "warning", warning)
+		}
+		pricingHolder.Swap(pricingCatalog)
 	}
 
 	if r.level != nil {

--- a/internal/pricing/catalog.go
+++ b/internal/pricing/catalog.go
@@ -1,0 +1,164 @@
+package pricing
+
+import (
+	"sort"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+type Catalog struct {
+	entries map[string]Entry
+	globs   []globEntry
+	loaded  time.Time
+	sources []string
+}
+
+type globEntry struct {
+	pattern string
+	prefix  string
+	entry   Entry
+}
+
+type Holder struct {
+	ptr atomic.Pointer[Catalog]
+}
+
+func NewHolder(catalog *Catalog) *Holder {
+	holder := &Holder{}
+	if catalog == nil {
+		catalog = emptyCatalog()
+	}
+	holder.Swap(catalog)
+	return holder
+}
+
+func (h *Holder) Current() *Catalog {
+	if h == nil {
+		return nil
+	}
+	return h.ptr.Load()
+}
+
+func (h *Holder) Swap(catalog *Catalog) {
+	if h == nil {
+		return
+	}
+	if catalog == nil {
+		catalog = emptyCatalog()
+	}
+	h.ptr.Store(catalog)
+}
+
+func (h *Holder) Lookup(modelID string) (Entry, bool) {
+	catalog := h.Current()
+	if catalog == nil {
+		return Entry{}, false
+	}
+	return catalog.Lookup(modelID)
+}
+
+func (h *Holder) Estimate(req EstimateRequest) EstimateResult {
+	catalog := h.Current()
+	if catalog == nil {
+		return missingResult(LookupMiss)
+	}
+	return catalog.Estimate(req)
+}
+
+func (c *Catalog) Lookup(modelID string) (Entry, bool) {
+	entry, ok, _ := c.lookup(modelID)
+	return entry, ok
+}
+
+func (c *Catalog) lookup(modelID string) (Entry, bool, string) {
+	if c == nil {
+		return Entry{}, false, LookupMiss
+	}
+	modelID = strings.TrimSpace(modelID)
+	if modelID == "" {
+		return Entry{}, false, LookupMiss
+	}
+	if entry, ok := c.entries[modelID]; ok {
+		return entry, true, LookupHit
+	}
+	for _, candidate := range c.globs {
+		if strings.HasPrefix(modelID, candidate.prefix) {
+			return candidate.entry, true, LookupGlobHit
+		}
+	}
+	return Entry{}, false, LookupMiss
+}
+
+func (c *Catalog) Sources() []string {
+	if c == nil {
+		return nil
+	}
+	out := make([]string, len(c.sources))
+	copy(out, c.sources)
+	return out
+}
+
+func (c *Catalog) LoadedAt() time.Time {
+	if c == nil {
+		return time.Time{}
+	}
+	return c.loaded
+}
+
+func (c *Catalog) Entries() map[string]Entry {
+	if c == nil {
+		return nil
+	}
+	out := make(map[string]Entry, len(c.entries)+len(c.globs))
+	for key, entry := range c.entries {
+		out[key] = entry
+	}
+	for _, glob := range c.globs {
+		out[glob.pattern] = glob.entry
+	}
+	return out
+}
+
+func newCatalog(entries map[string]Entry, loaded time.Time, sources []string) *Catalog {
+	if loaded.IsZero() {
+		loaded = time.Now().UTC()
+	}
+	catalog := &Catalog{
+		entries: make(map[string]Entry),
+		loaded:  loaded,
+		sources: append([]string(nil), sources...),
+	}
+
+	keys := make([]string, 0, len(entries))
+	for key := range entries {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		entry := entries[key]
+		if strings.HasSuffix(key, "*") {
+			catalog.globs = append(catalog.globs, globEntry{
+				pattern: key,
+				prefix:  strings.TrimSuffix(key, "*"),
+				entry:   entry,
+			})
+			continue
+		}
+		catalog.entries[key] = entry
+	}
+	sort.Slice(catalog.globs, func(i, j int) bool {
+		if len(catalog.globs[i].prefix) != len(catalog.globs[j].prefix) {
+			return len(catalog.globs[i].prefix) > len(catalog.globs[j].prefix)
+		}
+		return catalog.globs[i].pattern < catalog.globs[j].pattern
+	})
+	return catalog
+}
+
+func emptyCatalog() *Catalog {
+	return &Catalog{
+		entries: map[string]Entry{},
+		loaded:  time.Now().UTC(),
+	}
+}

--- a/internal/pricing/catalog_test.go
+++ b/internal/pricing/catalog_test.go
@@ -1,0 +1,89 @@
+package pricing
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestLoadBundledAndLookup(t *testing.T) {
+	catalog, err := LoadBundled()
+	if err != nil {
+		t.Fatalf("LoadBundled() error = %v", err)
+	}
+	if _, ok := catalog.Lookup("openai/gpt-4o"); !ok {
+		t.Fatalf("expected bundled openai/gpt-4o pricing")
+	}
+	if _, ok := catalog.Lookup("ollama/llama3.3"); !ok {
+		t.Fatalf("expected ollama wildcard pricing")
+	}
+}
+
+func TestLoadOverridePrecedenceAndEnvExpansion(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pricing.yaml")
+	t.Setenv("PRICE_SOURCE", "https://example.test/pricing")
+	if err := os.WriteFile(path, []byte(`
+version: 1
+models:
+  openai/gpt-4o:
+    mode: chat
+    source: ${PRICE_SOURCE}
+    pricing: { input_per_mtok: 99.00, output_per_mtok: 101.00 }
+  custom/model:
+    mode: chat
+    pricing: { input_per_mtok: 1.00, output_per_mtok: 2.00 }
+`), 0o600); err != nil {
+		t.Fatalf("write override: %v", err)
+	}
+
+	catalog, warnings, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings, got %v", warnings)
+	}
+	entry, ok := catalog.Lookup("openai/gpt-4o")
+	if !ok {
+		t.Fatalf("expected override entry")
+	}
+	if entry.Pricing == nil || entry.Pricing.InputPerMTok != 99 || entry.Source != "https://example.test/pricing" {
+		t.Fatalf("override did not win: %#v", entry)
+	}
+	if _, ok := catalog.Lookup("custom/model"); !ok {
+		t.Fatalf("expected custom model from override")
+	}
+}
+
+func TestHolderSwap(t *testing.T) {
+	first := newCatalog(map[string]Entry{
+		"test/model": {Mode: "chat", Currency: "USD", Pricing: &Rates{InputPerMTok: 1}},
+	}, time.Now().UTC(), []string{"first"})
+	second := newCatalog(map[string]Entry{
+		"test/model": {Mode: "chat", Currency: "USD", Pricing: &Rates{InputPerMTok: 2}},
+	}, time.Now().UTC(), []string{"second"})
+
+	holder := NewHolder(first)
+	if got := holder.Estimate(EstimateRequest{Model: "test/model", InputTokens: 1_000_000}).TotalUSD; got != 1 {
+		t.Fatalf("expected first catalog cost 1, got %.2f", got)
+	}
+	holder.Swap(second)
+	if got := holder.Estimate(EstimateRequest{Model: "test/model", InputTokens: 1_000_000}).TotalUSD; got != 2 {
+		t.Fatalf("expected swapped catalog cost 2, got %.2f", got)
+	}
+}
+
+func TestInvalidYAMLRejected(t *testing.T) {
+	_, err := parseFile([]byte(`
+version: 1
+models:
+  badmodel:
+    mode: chat
+    pricing: { input_per_mtok: -1 }
+`), "test.yaml")
+	if err == nil {
+		t.Fatalf("expected invalid pricing yaml to be rejected")
+	}
+}

--- a/internal/pricing/data/anthropic.yaml
+++ b/internal/pricing/data/anthropic.yaml
@@ -1,0 +1,125 @@
+version: 1
+models:
+  anthropic/claude-opus-4-7:
+    mode: chat
+    currency: USD
+    context_window: 1000000
+    source: https://platform.claude.com/docs/en/docs/about-claude/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 5.00, output_per_mtok: 25.00, cache_read_per_mtok: 0.50, cache_write_5m_per_mtok: 6.25, cache_write_1h_per_mtok: 10.00 }
+    tiers:
+      batch: { multiplier: 0.5 }
+    deployments:
+      us: { multiplier: 1.10 }
+      fast: { multiplier: 6.00 }
+    additional_units:
+      web_search_per_1k_calls: 10.00
+      code_exec_per_container_hour: 0.05
+
+  anthropic/claude-opus-4-6:
+    mode: chat
+    currency: USD
+    context_window: 1000000
+    source: https://platform.claude.com/docs/en/docs/about-claude/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 15.00, output_per_mtok: 75.00, cache_read_per_mtok: 1.50, cache_write_5m_per_mtok: 18.75, cache_write_1h_per_mtok: 30.00 }
+    tiers:
+      batch: { multiplier: 0.5 }
+    deployments:
+      us: { multiplier: 1.10 }
+      fast: { multiplier: 6.00 }
+    additional_units:
+      web_search_per_1k_calls: 10.00
+      code_exec_per_container_hour: 0.05
+
+  anthropic/claude-opus-4-5:
+    mode: chat
+    currency: USD
+    context_window: 200000
+    source: https://platform.claude.com/docs/en/docs/about-claude/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 15.00, output_per_mtok: 75.00, cache_read_per_mtok: 1.50, cache_write_5m_per_mtok: 18.75, cache_write_1h_per_mtok: 30.00 }
+    tiers:
+      batch: { multiplier: 0.5 }
+    deprecation: { replacement: anthropic/claude-opus-4-6 }
+
+  anthropic/claude-opus-4-1:
+    mode: chat
+    currency: USD
+    context_window: 200000
+    source: https://platform.claude.com/docs/en/docs/about-claude/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 15.00, output_per_mtok: 75.00, cache_read_per_mtok: 1.50, cache_write_5m_per_mtok: 18.75, cache_write_1h_per_mtok: 30.00 }
+    tiers:
+      batch: { multiplier: 0.5 }
+    deprecation: { replacement: anthropic/claude-opus-4-6 }
+
+  anthropic/claude-sonnet-4-6:
+    mode: chat
+    currency: USD
+    context_window: 1000000
+    source: https://platform.claude.com/docs/en/docs/about-claude/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 3.00, output_per_mtok: 15.00, cache_read_per_mtok: 0.30, cache_write_5m_per_mtok: 3.75, cache_write_1h_per_mtok: 6.00 }
+    tiers:
+      batch: { multiplier: 0.5 }
+    deployments:
+      us: { multiplier: 1.10 }
+      fast: { multiplier: 6.00 }
+    additional_units:
+      web_search_per_1k_calls: 10.00
+      code_exec_per_container_hour: 0.05
+
+  anthropic/claude-sonnet-4-5:
+    mode: chat
+    currency: USD
+    context_window: 200000
+    source: https://platform.claude.com/docs/en/docs/about-claude/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 3.00, output_per_mtok: 15.00, cache_read_per_mtok: 0.30, cache_write_5m_per_mtok: 3.75, cache_write_1h_per_mtok: 6.00 }
+    tiers:
+      batch: { multiplier: 0.5 }
+    deprecation: { replacement: anthropic/claude-sonnet-4-6 }
+
+  anthropic/claude-haiku-4-5:
+    mode: chat
+    currency: USD
+    context_window: 200000
+    source: https://platform.claude.com/docs/en/docs/about-claude/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 1.00, output_per_mtok: 5.00, cache_read_per_mtok: 0.10, cache_write_5m_per_mtok: 1.25, cache_write_1h_per_mtok: 2.00 }
+    tiers:
+      batch: { multiplier: 0.5 }
+
+  anthropic/claude-haiku-3-5:
+    mode: chat
+    currency: USD
+    context_window: 200000
+    source: https://platform.claude.com/docs/en/docs/about-claude/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.80, output_per_mtok: 4.00, cache_read_per_mtok: 0.08, cache_write_5m_per_mtok: 1.00, cache_write_1h_per_mtok: 1.60 }
+    tiers:
+      batch: { multiplier: 0.5 }
+    deprecation: { replacement: anthropic/claude-haiku-4-5 }
+
+  anthropic/claude-3-opus:
+    mode: chat
+    currency: USD
+    context_window: 200000
+    source: https://platform.claude.com/docs/en/docs/about-claude/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 15.00, output_per_mtok: 75.00, cache_read_per_mtok: 1.50, cache_write_5m_per_mtok: 18.75, cache_write_1h_per_mtok: 30.00 }
+    tiers:
+      batch: { multiplier: 0.5 }
+    deprecation: { replacement: anthropic/claude-opus-4-6 }
+
+  anthropic/claude-3-haiku:
+    mode: chat
+    currency: USD
+    context_window: 200000
+    source: https://platform.claude.com/docs/en/docs/about-claude/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.25, output_per_mtok: 1.25, cache_read_per_mtok: 0.025, cache_write_5m_per_mtok: 0.3125, cache_write_1h_per_mtok: 0.50 }
+    tiers:
+      batch: { multiplier: 0.5 }
+    deprecation: { replacement: anthropic/claude-haiku-4-5 }

--- a/internal/pricing/data/bytedance.yaml
+++ b/internal/pricing/data/bytedance.yaml
@@ -1,0 +1,243 @@
+version: 1
+models:
+  bytedance/doubao-seed-2-0-pro:
+    mode: chat
+    currency: USD
+    context_window: 256000
+    source: https://www.volcengine.com/docs/82379
+    effective_from: 2026-04-01
+    tiered_pricing:
+      - id: lte_32k
+        range: [0, 32000]
+        input_per_mtok: 0.80
+        output_per_mtok: 2.40
+      - id: lte_128k
+        range: [32000, 128000]
+        input_per_mtok: 1.20
+        output_per_mtok: 3.60
+      - id: lte_256k
+        range: [128000, 256000]
+        input_per_mtok: 2.40
+        output_per_mtok: 7.20
+
+  bytedance/doubao-seed-2.0-pro:
+    mode: chat
+    currency: USD
+    context_window: 256000
+    source: https://www.volcengine.com/docs/82379
+    effective_from: 2026-04-01
+    tiered_pricing:
+      - id: lte_32k
+        range: [0, 32000]
+        input_per_mtok: 0.80
+        output_per_mtok: 2.40
+      - id: lte_128k
+        range: [32000, 128000]
+        input_per_mtok: 1.20
+        output_per_mtok: 3.60
+      - id: lte_256k
+        range: [128000, 256000]
+        input_per_mtok: 2.40
+        output_per_mtok: 7.20
+
+  bytedance/doubao-seed-2-0-lite:
+    mode: chat
+    currency: USD
+    context_window: 256000
+    source: https://www.volcengine.com/docs/82379
+    effective_from: 2026-04-01
+    tiered_pricing:
+      - id: lte_32k
+        range: [0, 32000]
+        input_per_mtok: 0.15
+        output_per_mtok: 0.60
+      - id: lte_128k
+        range: [32000, 128000]
+        input_per_mtok: 0.30
+        output_per_mtok: 1.20
+      - id: lte_256k
+        range: [128000, 256000]
+        input_per_mtok: 0.60
+        output_per_mtok: 2.40
+
+  bytedance/doubao-seed-1.6-vision:
+    mode: chat
+    currency: USD
+    context_window: 256000
+    source: https://www.volcengine.com/docs/82379
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.80, output_per_mtok: 2.40 }
+
+  bytedance/doubao-seed-2-0-mini:
+    mode: chat
+    currency: USD
+    context_window: 128000
+    source: https://www.volcengine.com/docs/82379
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.03, output_per_mtok: 0.12 }
+
+  bytedance/doubao-pro:
+    mode: chat
+    currency: USD
+    context_window: 128000
+    source: https://www.volcengine.com/docs/82379
+    effective_from: 2026-04-01
+    notes: Legacy configured model retained for compatibility.
+    pricing: { input_per_mtok: 0.80, output_per_mtok: 2.40 }
+    deprecation: { replacement: bytedance/doubao-seed-2-0-pro }
+
+  bytedance/doubao-pro-256k:
+    mode: chat
+    currency: USD
+    context_window: 256000
+    source: https://www.volcengine.com/docs/82379
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.80, output_per_mtok: 2.40 }
+    deprecation: { replacement: bytedance/doubao-seed-2.0-pro }
+
+  bytedance/doubao-lite:
+    mode: chat
+    currency: USD
+    context_window: 128000
+    source: https://www.volcengine.com/docs/82379
+    effective_from: 2026-04-01
+    notes: Legacy configured model retained for compatibility.
+    pricing: { input_per_mtok: 0.15, output_per_mtok: 0.60 }
+    deprecation: { replacement: bytedance/doubao-seed-2-0-lite }
+
+  bytedance/doubao-1.5:
+    mode: chat
+    currency: USD
+    context_window: 128000
+    source: https://www.volcengine.com/docs/82379
+    effective_from: 2026-04-01
+    notes: Legacy configured model retained for compatibility.
+    pricing: { input_per_mtok: 0.80, output_per_mtok: 2.40 }
+    deprecation: { replacement: bytedance/doubao-seed-2-0-pro }
+
+  bytedance/seedance-2-0:
+    mode: video
+    currency: USD
+    source: https://www.volcengine.com/docs/82379
+    effective_from: 2026-04-01
+    pricing: { input_per_video_second: 0.14 }
+
+  bytedance/doubao-seedance-2.0:
+    mode: video
+    currency: USD
+    source: https://www.volcengine.com/docs/82379
+    effective_from: 2026-04-01
+    pricing: { input_per_video_second: 0.14 }
+
+  bytedance/doubao-seedance-2.0-fast:
+    mode: video
+    currency: USD
+    source: https://www.volcengine.com/docs/82379
+    effective_from: 2026-04-01
+    pricing: { input_per_video_second: 0.07 }
+
+  bytedance/seedance-2.0:
+    mode: video
+    currency: USD
+    source: https://www.volcengine.com/docs/82379
+    effective_from: 2026-04-01
+    pricing: { input_per_video_second: 0.14 }
+
+  bytedance/seedance-2.0-fast:
+    mode: video
+    currency: USD
+    source: https://www.volcengine.com/docs/82379
+    effective_from: 2026-04-01
+    pricing: { input_per_video_second: 0.07 }
+
+  bytedance/doubao-seedream-5.0-lite:
+    mode: image_generation
+    currency: USD
+    source: https://www.volcengine.com/docs/82379
+    effective_from: 2026-04-01
+    pricing: { output_per_image: 0.02 }
+
+  bytedance/seedream-4.5:
+    mode: image_generation
+    currency: USD
+    source: https://www.volcengine.com/docs/82379
+    effective_from: 2026-04-01
+    pricing: { output_per_image: 0.04 }
+
+  bytedance/doubao-embedding:
+    mode: embedding
+    currency: USD
+    context_window: 8192
+    source: https://www.volcengine.com/docs/82379
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.02 }
+
+  bytedance/doubao-asr-2.0:
+    mode: audio_transcription
+    currency: USD
+    source: https://www.volcengine.com/docs/6561
+    effective_from: 2026-04-01
+    pricing: { input_per_audio_second: 0.00008 }
+
+  bytedance/doubao-tts:
+    mode: audio_speech
+    currency: USD
+    source: https://www.volcengine.com/docs/6561
+    effective_from: 2026-04-01
+    pricing: { input_per_character: 0.000004 }
+
+  bytedance/doubao-tts-2.0:
+    mode: audio_speech
+    currency: USD
+    source: https://www.volcengine.com/docs/6561
+    effective_from: 2026-04-01
+    pricing: { input_per_character: 0.000004 }
+
+  bytedance/doubao-streaming-asr-2.0:
+    mode: audio_transcription
+    currency: USD
+    source: https://www.volcengine.com/docs/6561
+    effective_from: 2026-04-01
+    pricing: { input_per_audio_second: 0.00008 }
+
+  bytedance/doubao-streaming-asr-2.0-concurrent:
+    mode: audio_transcription
+    currency: USD
+    source: https://www.volcengine.com/docs/6561
+    effective_from: 2026-04-01
+    pricing: { input_per_audio_second: 0.00008 }
+
+  bytedance/doubao-audio:
+    mode: audio
+    currency: USD
+    source: https://www.volcengine.com/docs/6561
+    effective_from: 2026-04-01
+    pricing: { input_per_audio_second: 0.00008, output_per_audio_second: 0.00008 }
+
+  bytedance/doubao-interpreting-2.0:
+    mode: interpreting
+    currency: USD
+    source: https://www.volcengine.com/docs/6561
+    effective_from: 2026-04-01
+    pricing: { input_per_audio_second: 0.00010, output_per_audio_second: 0.00010 }
+
+  bytedance/doubao-translation-2.0:
+    mode: translation
+    currency: USD
+    source: https://www.volcengine.com/docs/6561
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.20, output_per_mtok: 0.20 }
+
+  bytedance/doubao-notes-2.0:
+    mode: notes
+    currency: USD
+    source: https://www.volcengine.com/docs/6561
+    effective_from: 2026-04-01
+    pricing: { input_per_audio_second: 0.00008 }
+
+  bytedance/doubao-podcast-2.0:
+    mode: podcast
+    currency: USD
+    source: https://www.volcengine.com/docs/6561
+    effective_from: 2026-04-01
+    pricing: { input_per_character: 0.000004 }

--- a/internal/pricing/data/deepseek.yaml
+++ b/internal/pricing/data/deepseek.yaml
@@ -1,0 +1,33 @@
+version: 1
+models:
+  deepseek/deepseek-chat:
+    mode: chat
+    currency: USD
+    context_window: 128000
+    source: https://api-docs.deepseek.com/quick_start/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.28, input_cache_hit_per_mtok: 0.028, output_per_mtok: 0.28 }
+
+  deepseek/deepseek-reasoner:
+    mode: chat
+    currency: USD
+    context_window: 128000
+    source: https://api-docs.deepseek.com/quick_start/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.55, input_cache_hit_per_mtok: 0.055, output_per_mtok: 2.19, output_reasoning_per_mtok: 2.19 }
+
+  deepseek/deepseek-v4-flash:
+    mode: chat
+    currency: USD
+    context_window: 128000
+    source: https://api-docs.deepseek.com/quick_start/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.145, input_cache_hit_per_mtok: 0.0145, output_per_mtok: 0.58 }
+
+  deepseek/deepseek-v4-pro:
+    mode: chat
+    currency: USD
+    context_window: 128000
+    source: https://api-docs.deepseek.com/quick_start/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.55, input_cache_hit_per_mtok: 0.055, output_per_mtok: 2.19, output_reasoning_per_mtok: 2.19 }

--- a/internal/pricing/data/elevenlabs.yaml
+++ b/internal/pricing/data/elevenlabs.yaml
@@ -1,0 +1,8 @@
+version: 1
+models:
+  elevenlabs/music_v1:
+    mode: music
+    currency: USD
+    source: https://elevenlabs.io/music-api
+    effective_from: 2026-04-01
+    pricing: { per_call: 0.06 }

--- a/internal/pricing/data/google.yaml
+++ b/internal/pricing/data/google.yaml
@@ -1,0 +1,165 @@
+version: 1
+models:
+  google/gemini-2.5-pro:
+    mode: chat
+    currency: USD
+    context_window: 1000000
+    source: https://ai.google.dev/gemini-api/docs/pricing
+    effective_from: 2026-04-01
+    tiered_pricing:
+      - id: lt_200k
+        range: [0, 200000]
+        input_per_mtok: 1.25
+        output_per_mtok: 10.00
+        cache_read_per_mtok: 0.125
+      - id: gte_200k
+        range: [200000, 1000000]
+        input_per_mtok: 2.50
+        output_per_mtok: 15.00
+        cache_read_per_mtok: 0.25
+    additional_units:
+      google_search_grounding_per_1k_calls: 35.00
+
+  google/gemini-2.5-flash:
+    mode: chat
+    currency: USD
+    context_window: 1000000
+    source: https://ai.google.dev/gemini-api/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.30, output_per_mtok: 2.50, output_reasoning_per_mtok: 2.50, cache_read_per_mtok: 0.03 }
+    tiers:
+      batch: { multiplier: 0.5 }
+    additional_units:
+      google_search_grounding_per_1k_calls: 35.00
+
+  google/gemini-2.5-flash-lite:
+    mode: chat
+    currency: USD
+    context_window: 1000000
+    source: https://ai.google.dev/gemini-api/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.10, output_per_mtok: 0.40, output_reasoning_per_mtok: 0.40, cache_read_per_mtok: 0.025 }
+    tiers:
+      batch: { multiplier: 0.5 }
+
+  google/gemini-2.0-flash:
+    mode: chat
+    currency: USD
+    context_window: 1000000
+    source: https://ai.google.dev/gemini-api/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.10, output_per_mtok: 0.40, cache_read_per_mtok: 0.025 }
+    deprecation: { replacement: google/gemini-2.5-flash }
+
+  google/gemini-1.5-pro:
+    mode: chat
+    currency: USD
+    context_window: 2000000
+    source: https://ai.google.dev/gemini-api/docs/pricing
+    effective_from: 2026-04-01
+    notes: Legacy model retained for existing configs.
+    tiered_pricing:
+      - id: lt_128k
+        range: [0, 128000]
+        input_per_mtok: 1.25
+        output_per_mtok: 5.00
+      - id: gte_128k
+        range: [128000, 2000000]
+        input_per_mtok: 2.50
+        output_per_mtok: 10.00
+    deprecation: { replacement: google/gemini-2.5-pro }
+
+  google/gemini-1.5-flash:
+    mode: chat
+    currency: USD
+    context_window: 1000000
+    source: https://ai.google.dev/gemini-api/docs/pricing
+    effective_from: 2026-04-01
+    notes: Legacy model retained for existing configs.
+    tiered_pricing:
+      - id: lt_128k
+        range: [0, 128000]
+        input_per_mtok: 0.075
+        output_per_mtok: 0.30
+      - id: gte_128k
+        range: [128000, 1000000]
+        input_per_mtok: 0.15
+        output_per_mtok: 0.60
+    deprecation: { replacement: google/gemini-2.5-flash }
+
+  google/text-embedding-004:
+    mode: embedding
+    currency: USD
+    context_window: 2048
+    source: https://ai.google.dev/gemini-api/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.01 }
+
+  google/gemini-embedding-001:
+    mode: embedding
+    currency: USD
+    context_window: 8192
+    source: https://ai.google.dev/gemini-api/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.15 }
+
+  google/imagen-4:
+    mode: image_generation
+    currency: USD
+    source: https://ai.google.dev/gemini-api/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { output_per_image: 0.04 }
+
+  google/imagen-4-ultra:
+    mode: image_generation
+    currency: USD
+    source: https://ai.google.dev/gemini-api/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { output_per_image: 0.06 }
+
+  google/imagen-3:
+    mode: image_generation
+    currency: USD
+    source: https://ai.google.dev/gemini-api/docs/pricing
+    effective_from: 2026-04-01
+    notes: Legacy Imagen rate retained for older configs.
+    pricing: { output_per_image: 0.04 }
+    deprecation: { replacement: google/imagen-4 }
+
+  google/gemini-flash-image:
+    mode: image_generation
+    currency: USD
+    context_window: 32000
+    source: https://ai.google.dev/gemini-api/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.30, output_per_image: 0.039 }
+
+  google/nano-banana-2:
+    mode: image_generation
+    currency: USD
+    context_window: 32000
+    source: https://ai.google.dev/gemini-api/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.30, output_per_image: 0.039 }
+
+  google/nano-banana-pro:
+    mode: image_generation
+    currency: USD
+    context_window: 32000
+    source: https://ai.google.dev/gemini-api/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 1.25, output_per_image: 0.060 }
+
+  google-vertex/veo-3.1-generate-001:
+    mode: video
+    currency: USD
+    source: https://cloud.google.com/vertex-ai/generative-ai/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_video_second: 0.35 }
+
+  google-vertex/veo-3.1-fast-generate-001:
+    mode: video
+    currency: USD
+    source: https://cloud.google.com/vertex-ai/generative-ai/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_video_second: 0.15 }

--- a/internal/pricing/data/minimax.yaml
+++ b/internal/pricing/data/minimax.yaml
@@ -1,0 +1,15 @@
+version: 1
+models:
+  minimax/music-2.6:
+    mode: music
+    currency: USD
+    source: https://platform.minimax.io/docs/guides/music-generation-api-refer
+    effective_from: 2026-04-01
+    pricing: { per_call: 0.06 }
+
+  minimax/music-cover:
+    mode: music
+    currency: USD
+    source: https://platform.minimax.io/docs/guides/music-generation-api-refer
+    effective_from: 2026-04-01
+    pricing: { per_call: 0.06 }

--- a/internal/pricing/data/ollama.yaml
+++ b/internal/pricing/data/ollama.yaml
@@ -1,0 +1,9 @@
+version: 1
+models:
+  ollama/*:
+    mode: chat
+    currency: USD
+    source: https://ollama.com/
+    effective_from: 2026-04-01
+    notes: Local Ollama runtime requests are treated as zero marginal provider cost by default.
+    pricing: { input_per_mtok: 0, output_per_mtok: 0 }

--- a/internal/pricing/data/openai.yaml
+++ b/internal/pricing/data/openai.yaml
@@ -1,0 +1,254 @@
+version: 1
+models:
+  openai/gpt-5.5:
+    mode: chat
+    currency: USD
+    context_window: 1000000
+    source: https://platform.openai.com/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 5.00, output_per_mtok: 20.00, output_reasoning_per_mtok: 20.00, cache_read_per_mtok: 1.25 }
+    tiers:
+      batch: { multiplier: 0.5 }
+
+  openai/gpt-5.4:
+    mode: chat
+    currency: USD
+    context_window: 1000000
+    source: https://platform.openai.com/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 3.00, output_per_mtok: 12.00, output_reasoning_per_mtok: 12.00, cache_read_per_mtok: 0.75 }
+    tiers:
+      batch: { multiplier: 0.5 }
+
+  openai/gpt-5.4-mini:
+    mode: chat
+    currency: USD
+    context_window: 1000000
+    source: https://platform.openai.com/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.60, output_per_mtok: 2.40, output_reasoning_per_mtok: 2.40, cache_read_per_mtok: 0.15 }
+    tiers:
+      batch: { multiplier: 0.5 }
+
+  openai/gpt-5.4-nano:
+    mode: chat
+    currency: USD
+    context_window: 1000000
+    source: https://platform.openai.com/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.15, output_per_mtok: 0.60, output_reasoning_per_mtok: 0.60, cache_read_per_mtok: 0.0375 }
+    tiers:
+      batch: { multiplier: 0.5 }
+
+  openai/gpt-5.3-codex:
+    mode: chat
+    currency: USD
+    context_window: 400000
+    source: https://platform.openai.com/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 1.25, output_per_mtok: 10.00, output_reasoning_per_mtok: 10.00, cache_read_per_mtok: 0.125 }
+
+  openai/gpt-4o:
+    mode: chat
+    currency: USD
+    context_window: 128000
+    source: https://platform.openai.com/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 5.00, output_per_mtok: 15.00, cache_read_per_mtok: 2.50 }
+    tiers:
+      batch: { multiplier: 0.5 }
+      flex: { input_per_mtok: 2.50, output_per_mtok: 7.50, cache_read_per_mtok: 1.25 }
+      priority: { input_per_mtok: 8.50, output_per_mtok: 25.50 }
+
+  openai/gpt-4o-mini:
+    mode: chat
+    currency: USD
+    context_window: 128000
+    source: https://platform.openai.com/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.15, output_per_mtok: 0.60, cache_read_per_mtok: 0.075 }
+    tiers:
+      batch: { multiplier: 0.5 }
+
+  openai/gpt-4.1:
+    mode: chat
+    currency: USD
+    context_window: 1000000
+    source: https://platform.openai.com/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 2.00, output_per_mtok: 8.00, cache_read_per_mtok: 0.50 }
+    tiers:
+      batch: { multiplier: 0.5 }
+
+  openai/gpt-4.1-mini:
+    mode: chat
+    currency: USD
+    context_window: 1000000
+    source: https://platform.openai.com/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.40, output_per_mtok: 1.60, cache_read_per_mtok: 0.10 }
+    tiers:
+      batch: { multiplier: 0.5 }
+
+  openai/gpt-4.1-nano:
+    mode: chat
+    currency: USD
+    context_window: 1000000
+    source: https://platform.openai.com/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.10, output_per_mtok: 0.40, cache_read_per_mtok: 0.025 }
+    tiers:
+      batch: { multiplier: 0.5 }
+
+  openai/o1:
+    mode: chat
+    currency: USD
+    context_window: 200000
+    source: https://platform.openai.com/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 15.00, output_per_mtok: 60.00, output_reasoning_per_mtok: 60.00, cache_read_per_mtok: 7.50 }
+
+  openai/o1-mini:
+    mode: chat
+    currency: USD
+    context_window: 128000
+    source: https://platform.openai.com/docs/pricing
+    effective_from: 2026-04-01
+    notes: Conservative legacy rate retained for configured aliases.
+    pricing: { input_per_mtok: 1.10, output_per_mtok: 4.40, output_reasoning_per_mtok: 4.40, cache_read_per_mtok: 0.55 }
+    deprecation: { replacement: openai/o3-mini }
+
+  openai/o3:
+    mode: chat
+    currency: USD
+    context_window: 200000
+    source: https://platform.openai.com/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 2.00, output_per_mtok: 8.00, output_reasoning_per_mtok: 8.00, cache_read_per_mtok: 0.50 }
+    tiers:
+      flex: { input_per_mtok: 1.00, output_per_mtok: 4.00, output_reasoning_per_mtok: 4.00, cache_read_per_mtok: 0.25 }
+      priority: { input_per_mtok: 3.50, output_per_mtok: 14.00, output_reasoning_per_mtok: 14.00 }
+
+  openai/o3-mini:
+    mode: chat
+    currency: USD
+    context_window: 200000
+    source: https://platform.openai.com/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 1.10, output_per_mtok: 4.40, output_reasoning_per_mtok: 4.40, cache_read_per_mtok: 0.55 }
+
+  openai/o4-mini:
+    mode: chat
+    currency: USD
+    context_window: 200000
+    source: https://platform.openai.com/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 1.10, output_per_mtok: 4.40, output_reasoning_per_mtok: 4.40, cache_read_per_mtok: 0.275 }
+    tiers:
+      flex: { input_per_mtok: 0.55, output_per_mtok: 2.20, output_reasoning_per_mtok: 2.20 }
+      priority: { input_per_mtok: 1.925, output_per_mtok: 7.70, output_reasoning_per_mtok: 7.70 }
+
+  openai/text-embedding-3-small:
+    mode: embedding
+    currency: USD
+    context_window: 8191
+    source: https://platform.openai.com/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.02 }
+    tiers:
+      batch: { multiplier: 0.5 }
+
+  openai/text-embedding-3-large:
+    mode: embedding
+    currency: USD
+    context_window: 8191
+    source: https://platform.openai.com/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.13 }
+    tiers:
+      batch: { multiplier: 0.5 }
+
+  openai/text-embedding-ada-002:
+    mode: embedding
+    currency: USD
+    context_window: 8191
+    source: https://platform.openai.com/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.10 }
+    deprecation: { replacement: openai/text-embedding-3-small }
+
+  openai/dall-e-3:
+    mode: image_generation
+    currency: USD
+    source: https://platform.openai.com/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { output_per_image: 0.04 }
+
+  openai/gpt-image-1:
+    mode: image_generation
+    currency: USD
+    context_window: 128000
+    source: https://platform.openai.com/docs/pricing
+    effective_from: 2026-04-01
+    pricing:
+      input_per_mtok: 5.00
+      input_image_token_per_mtok: 10.00
+      output_image_token_per_mtok: 40.00
+      cache_read_per_mtok: 1.25
+      output_per_image: 0.04
+
+  openai/gpt-image-2:
+    mode: image_generation
+    currency: USD
+    context_window: 128000
+    source: https://platform.openai.com/docs/pricing
+    effective_from: 2026-04-01
+    pricing:
+      input_per_mtok: 5.00
+      input_image_token_per_mtok: 10.00
+      output_image_token_per_mtok: 40.00
+      cache_read_per_mtok: 1.25
+      output_per_image: 0.06
+
+  openai/whisper-1:
+    mode: audio_transcription
+    currency: USD
+    source: https://platform.openai.com/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_audio_second: 0.0001 }
+
+  openai/tts-1:
+    mode: audio_speech
+    currency: USD
+    source: https://platform.openai.com/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_character: 0.000015 }
+
+  openai/tts-1-hd:
+    mode: audio_speech
+    currency: USD
+    source: https://platform.openai.com/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_character: 0.000030 }
+
+  openai/gpt-4o-audio:
+    mode: audio
+    currency: USD
+    context_window: 128000
+    source: https://platform.openai.com/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 5.00, output_per_mtok: 20.00, input_per_audio_second: 0.0001, output_per_audio_second: 0.0002, cache_read_per_mtok: 2.50 }
+
+  openai/sora-2:
+    mode: video
+    currency: USD
+    source: https://platform.openai.com/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_video_second: 0.10 }
+
+  openai/sora-2-pro:
+    mode: video
+    currency: USD
+    source: https://platform.openai.com/docs/pricing
+    effective_from: 2026-04-01
+    pricing: { input_per_video_second: 0.30 }

--- a/internal/pricing/data/qwen.yaml
+++ b/internal/pricing/data/qwen.yaml
@@ -1,0 +1,76 @@
+version: 1
+models:
+  qwen/qwen-max:
+    mode: chat
+    currency: USD
+    context_window: 32000
+    source: https://www.alibabacloud.com/help/en/model-studio/billing-for-model-studio
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 1.60, output_per_mtok: 6.40 }
+
+  qwen/qwen-plus:
+    mode: chat
+    currency: USD
+    context_window: 128000
+    source: https://www.alibabacloud.com/help/en/model-studio/billing-for-model-studio
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.40, output_per_mtok: 1.20 }
+
+  qwen/qwen-turbo:
+    mode: chat
+    currency: USD
+    context_window: 1000000
+    source: https://www.alibabacloud.com/help/en/model-studio/billing-for-model-studio
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.05, output_per_mtok: 0.20 }
+
+  qwen/qwen3.5-flash:
+    mode: chat
+    currency: USD
+    context_window: 128000
+    source: https://www.alibabacloud.com/help/en/model-studio/billing-for-model-studio
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.029, output_per_mtok: 0.287 }
+
+  qwen/qwen3-max:
+    mode: chat
+    currency: USD
+    context_window: 252000
+    source: https://www.alibabacloud.com/help/en/model-studio/billing-for-model-studio
+    effective_from: 2026-04-01
+    tiered_pricing:
+      - id: lte_32k
+        range: [0, 32000]
+        input_per_mtok: 1.20
+        output_per_mtok: 6.00
+      - id: lte_128k
+        range: [32000, 128000]
+        input_per_mtok: 2.40
+        output_per_mtok: 12.00
+      - id: lte_252k
+        range: [128000, 252000]
+        input_per_mtok: 3.00
+        output_per_mtok: 15.00
+
+  qwen/qwen3-vl-plus:
+    mode: chat
+    currency: USD
+    context_window: 128000
+    source: https://www.alibabacloud.com/help/en/model-studio/billing-for-model-studio
+    effective_from: 2026-04-01
+    tiered_pricing:
+      - id: lte_32k
+        range: [0, 32000]
+        input_per_mtok: 0.40
+        output_per_mtok: 1.20
+      - id: lte_128k
+        range: [32000, 128000]
+        input_per_mtok: 0.80
+        output_per_mtok: 2.40
+
+  qwen/qwen-image-2.0:
+    mode: image_generation
+    currency: USD
+    source: https://www.alibabacloud.com/help/en/model-studio/billing-for-model-studio
+    effective_from: 2026-04-01
+    pricing: { output_per_image: 0.02 }

--- a/internal/pricing/data/xai.yaml
+++ b/internal/pricing/data/xai.yaml
@@ -1,0 +1,69 @@
+version: 1
+models:
+  xai/grok-4:
+    mode: chat
+    currency: USD
+    context_window: 256000
+    source: https://docs.x.ai/docs/models
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 3.00, output_per_mtok: 15.00, cache_read_per_mtok: 0.75 }
+
+  xai/grok-3:
+    mode: chat
+    currency: USD
+    context_window: 131000
+    source: https://docs.x.ai/docs/models
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 3.00, output_per_mtok: 15.00, cache_read_per_mtok: 0.75 }
+    deprecation: { replacement: xai/grok-4 }
+
+  xai/grok-3-mini:
+    mode: chat
+    currency: USD
+    context_window: 131000
+    source: https://docs.x.ai/docs/models
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.30, output_per_mtok: 0.50, cache_read_per_mtok: 0.075 }
+
+  xai/grok-2:
+    mode: chat
+    currency: USD
+    context_window: 131000
+    source: https://docs.x.ai/docs/models
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 2.00, output_per_mtok: 10.00 }
+    deprecation: { replacement: xai/grok-4 }
+
+  xai/grok-4-fast-reasoning:
+    mode: chat
+    currency: USD
+    context_window: 256000
+    source: https://docs.x.ai/docs/models
+    effective_from: 2026-04-01
+    tiered_pricing:
+      - id: lte_128k
+        range: [0, 128000]
+        input_per_mtok: 0.20
+        output_per_mtok: 0.50
+        output_reasoning_per_mtok: 0.50
+      - id: gt_128k
+        range: [128000, 256000]
+        input_per_mtok: 0.40
+        output_per_mtok: 1.00
+        output_reasoning_per_mtok: 1.00
+
+  xai/grok-4.1-fast:
+    mode: chat
+    currency: USD
+    context_window: 256000
+    source: https://docs.x.ai/docs/models
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.20, output_per_mtok: 0.50, output_reasoning_per_mtok: 0.50 }
+
+  xai/grok-4-1-fast-reasoning:
+    mode: chat
+    currency: USD
+    context_window: 2000000
+    source: https://docs.x.ai/docs/models
+    effective_from: 2026-04-01
+    pricing: { input_per_mtok: 0.20, output_per_mtok: 0.50, output_reasoning_per_mtok: 0.50 }

--- a/internal/pricing/data_test.go
+++ b/internal/pricing/data_test.go
@@ -1,0 +1,72 @@
+package pricing
+
+import (
+	"io/fs"
+	"testing"
+)
+
+func TestBundledDataRoundTrips(t *testing.T) {
+	files, err := fs.Glob(embeddedData, "data/*.yaml")
+	if err != nil {
+		t.Fatalf("glob embedded data: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatalf("expected bundled pricing data")
+	}
+	for _, file := range files {
+		data, err := embeddedData.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		parsed, err := parseFile(data, file)
+		if err != nil {
+			t.Fatalf("parse %s: %v", file, err)
+		}
+		for key, entry := range parsed.Models {
+			if !validMode(entry.Mode) {
+				t.Fatalf("%s has invalid mode %q", key, entry.Mode)
+			}
+			if entry.Pricing == nil && len(entry.TieredPricing) == 0 {
+				t.Fatalf("%s has no pricing", key)
+			}
+			for tier := range entry.Tiers {
+				if !validTier(tier) {
+					t.Fatalf("%s has invalid tier %q", key, tier)
+				}
+			}
+		}
+	}
+}
+
+func TestBundledDataCoversPrimaryConfiguredModels(t *testing.T) {
+	catalog, err := LoadBundled()
+	if err != nil {
+		t.Fatalf("LoadBundled() error = %v", err)
+	}
+	for _, model := range []string{
+		"openai/gpt-5.5",
+		"openai/gpt-4o",
+		"openai/gpt-image-2",
+		"openai/gpt-4o-audio",
+		"openai/sora-2",
+		"anthropic/claude-sonnet-4-6",
+		"deepseek/deepseek-chat",
+		"google/gemini-2.5-flash-lite",
+		"google/nano-banana-pro",
+		"google-vertex/veo-3.1-fast-generate-001",
+		"xai/grok-4-1-fast-reasoning",
+		"qwen/qwen3.5-flash",
+		"qwen/qwen-image-2.0",
+		"bytedance/doubao-seed-2.0-pro",
+		"bytedance/doubao-tts-2.0",
+		"bytedance/doubao-seedance-2.0",
+		"bytedance/seedream-4.5",
+		"minimax/music-2.6",
+		"elevenlabs/music_v1",
+		"ollama/llama3",
+	} {
+		if _, ok := catalog.Lookup(model); !ok {
+			t.Fatalf("expected bundled pricing for %s", model)
+		}
+	}
+}

--- a/internal/pricing/default.go
+++ b/internal/pricing/default.go
@@ -1,0 +1,35 @@
+package pricing
+
+import "sync"
+
+var (
+	defaultOnce      sync.Once
+	defaultEstimator Estimator
+	defaultErr       error
+)
+
+func DefaultEstimator() Estimator {
+	defaultOnce.Do(func() {
+		catalog, err := LoadBundled()
+		if err != nil {
+			defaultErr = err
+			defaultEstimator = NewHolder(emptyCatalog())
+			return
+		}
+		defaultEstimator = catalog
+	})
+	return defaultEstimator
+}
+
+func DefaultError() error {
+	defaultOnce.Do(func() {
+		catalog, err := LoadBundled()
+		if err != nil {
+			defaultErr = err
+			defaultEstimator = NewHolder(emptyCatalog())
+			return
+		}
+		defaultEstimator = catalog
+	})
+	return defaultErr
+}

--- a/internal/pricing/embed.go
+++ b/internal/pricing/embed.go
@@ -1,0 +1,6 @@
+package pricing
+
+import "embed"
+
+//go:embed data/*.yaml
+var embeddedData embed.FS

--- a/internal/pricing/estimator.go
+++ b/internal/pricing/estimator.go
@@ -1,0 +1,297 @@
+package pricing
+
+import (
+	"fmt"
+	"math"
+	"strings"
+)
+
+const perMTok = 1_000_000.0
+
+func (c *Catalog) Estimate(req EstimateRequest) EstimateResult {
+	entry, ok, status := c.lookup(req.Model)
+	if !ok {
+		return missingResult(status)
+	}
+
+	result := EstimateResult{
+		Currency:     defaultCurrency(entry.Currency),
+		Source:       SourceTable,
+		BreakdownUSD: map[string]float64{},
+		LookupStatus: status,
+	}
+	rates, band := resolveRates(entry, req)
+	result.EffectiveBand = band
+	result.EffectiveTier = strings.TrimSpace(req.Tier)
+	if !hasBillableActivity(req) && rates.PerCall == 0 {
+		result.Source = SourceFallbackZero
+		return result
+	}
+
+	addTokenCost(result.BreakdownUSD, "input", billableInputTokens(req), rates.InputPerMTok)
+	cacheReadRate := rates.CacheReadPerMTok
+	if rates.InputCacheHitPerMTok != 0 {
+		cacheReadRate = rates.InputCacheHitPerMTok
+	}
+	addTokenCost(result.BreakdownUSD, "cache_read", req.CachedInputTokens, cacheReadRate)
+	addTokenCost(result.BreakdownUSD, "cache_write_5m", req.CacheWrite5mTokens, rates.CacheWrite5mPerMTok)
+	addTokenCost(result.BreakdownUSD, "cache_write_1h", req.CacheWrite1hTokens, rates.CacheWrite1hPerMTok)
+	addTokenCost(result.BreakdownUSD, "output", req.OutputTokens, rates.OutputPerMTok)
+
+	reasoningRate := rates.OutputReasoningPerMTok
+	if reasoningRate == 0 {
+		reasoningRate = rates.OutputPerMTok
+	}
+	addTokenCost(result.BreakdownUSD, "reasoning", req.ReasoningTokens, reasoningRate)
+	addTokenCost(result.BreakdownUSD, "input_image_tokens", req.InputImageTokens, rates.InputImageTokenPerMTok)
+	addTokenCost(result.BreakdownUSD, "output_image_tokens", req.OutputImageTokens, rates.OutputImageTokenPerMTok)
+
+	addUnitCost(result.BreakdownUSD, "audio_seconds", req.AudioSeconds, rates.InputPerAudioSecond)
+	addUnitCost(result.BreakdownUSD, "video_seconds", req.VideoSeconds, rates.InputPerVideoSecond)
+	addUnitCost(result.BreakdownUSD, "characters", float64(req.Characters), rates.InputPerCharacter)
+	addImageCost(result.BreakdownUSD, req.Images, rates)
+	if rates.PerCall > 0 {
+		result.BreakdownUSD["call"] = rates.PerCall
+	}
+	for name, count := range req.UnitCounts {
+		additionalCost(result.BreakdownUSD, name, count, entry.AdditionalUnits)
+	}
+
+	for _, cost := range result.BreakdownUSD {
+		result.TotalUSD += cost
+	}
+	result.TotalUSD = roundUSD(result.TotalUSD)
+	for key, cost := range result.BreakdownUSD {
+		result.BreakdownUSD[key] = roundUSD(cost)
+	}
+	return result
+}
+
+func resolveRates(entry Entry, req EstimateRequest) (Rates, string) {
+	rates := Rates{}
+	band := ""
+	if len(entry.TieredPricing) > 0 {
+		for _, candidate := range entry.TieredPricing {
+			if inRange(req.InputTokens, candidate.Range) {
+				rates = candidate.Rates
+				band = candidate.ID
+				if band == "" {
+					band = fmt.Sprintf("%d-%d", candidate.Range[0], candidate.Range[1])
+				}
+				break
+			}
+		}
+		if band == "" {
+			last := entry.TieredPricing[len(entry.TieredPricing)-1]
+			rates = last.Rates
+			band = last.ID
+			if band == "" {
+				band = fmt.Sprintf("%d-%d", last.Range[0], last.Range[1])
+			}
+		}
+	} else if entry.Pricing != nil {
+		rates = *entry.Pricing
+	}
+
+	if tier := strings.TrimSpace(req.Tier); tier != "" {
+		if override, ok := entry.Tiers[tier]; ok {
+			rates = applyRateOverride(rates, override)
+		}
+	}
+	if deployment := strings.TrimSpace(req.Deployment); deployment != "" {
+		if override, ok := entry.Deployments[deployment]; ok {
+			rates = applyRateOverride(rates, override)
+		}
+	}
+	return rates, band
+}
+
+func applyRateOverride(base Rates, override Rates) Rates {
+	if override.Multiplier > 0 {
+		base = multiplyRates(base, override.Multiplier)
+	}
+	if override.InputPerMTok != 0 {
+		base.InputPerMTok = override.InputPerMTok
+	}
+	if override.OutputPerMTok != 0 {
+		base.OutputPerMTok = override.OutputPerMTok
+	}
+	if override.OutputReasoningPerMTok != 0 {
+		base.OutputReasoningPerMTok = override.OutputReasoningPerMTok
+	}
+	if override.CacheReadPerMTok != 0 {
+		base.CacheReadPerMTok = override.CacheReadPerMTok
+	}
+	if override.CacheWrite5mPerMTok != 0 {
+		base.CacheWrite5mPerMTok = override.CacheWrite5mPerMTok
+	}
+	if override.CacheWrite1hPerMTok != 0 {
+		base.CacheWrite1hPerMTok = override.CacheWrite1hPerMTok
+	}
+	if override.InputCacheHitPerMTok != 0 {
+		base.InputCacheHitPerMTok = override.InputCacheHitPerMTok
+	}
+	if override.InputImageTokenPerMTok != 0 {
+		base.InputImageTokenPerMTok = override.InputImageTokenPerMTok
+	}
+	if override.OutputImageTokenPerMTok != 0 {
+		base.OutputImageTokenPerMTok = override.OutputImageTokenPerMTok
+	}
+	if override.InputPerAudioSecond != 0 {
+		base.InputPerAudioSecond = override.InputPerAudioSecond
+	}
+	if override.OutputPerAudioSecond != 0 {
+		base.OutputPerAudioSecond = override.OutputPerAudioSecond
+	}
+	if override.InputPerVideoSecond != 0 {
+		base.InputPerVideoSecond = override.InputPerVideoSecond
+	}
+	if override.OutputPerVideoSecond != 0 {
+		base.OutputPerVideoSecond = override.OutputPerVideoSecond
+	}
+	if override.InputPerCharacter != 0 {
+		base.InputPerCharacter = override.InputPerCharacter
+	}
+	if override.InputPerImage != 0 {
+		base.InputPerImage = override.InputPerImage
+	}
+	if override.OutputPerImage != 0 {
+		base.OutputPerImage = override.OutputPerImage
+	}
+	if override.OutputPerPixel != 0 {
+		base.OutputPerPixel = override.OutputPerPixel
+	}
+	if override.PerCall != 0 {
+		base.PerCall = override.PerCall
+	}
+	return base
+}
+
+func multiplyRates(rates Rates, multiplier float64) Rates {
+	rates.InputPerMTok *= multiplier
+	rates.OutputPerMTok *= multiplier
+	rates.OutputReasoningPerMTok *= multiplier
+	rates.CacheReadPerMTok *= multiplier
+	rates.CacheWrite5mPerMTok *= multiplier
+	rates.CacheWrite1hPerMTok *= multiplier
+	rates.InputCacheHitPerMTok *= multiplier
+	rates.InputImageTokenPerMTok *= multiplier
+	rates.OutputImageTokenPerMTok *= multiplier
+	rates.InputPerAudioSecond *= multiplier
+	rates.OutputPerAudioSecond *= multiplier
+	rates.InputPerVideoSecond *= multiplier
+	rates.OutputPerVideoSecond *= multiplier
+	rates.InputPerCharacter *= multiplier
+	rates.InputPerImage *= multiplier
+	rates.OutputPerImage *= multiplier
+	rates.OutputPerPixel *= multiplier
+	rates.PerCall *= multiplier
+	return rates
+}
+
+func billableInputTokens(req EstimateRequest) int {
+	return max(0, req.InputTokens-req.CachedInputTokens-req.CacheWrite5mTokens-req.CacheWrite1hTokens)
+}
+
+func addTokenCost(breakdown map[string]float64, key string, tokens int, ratePerMTok float64) {
+	if tokens <= 0 || ratePerMTok == 0 {
+		return
+	}
+	breakdown[key] += float64(tokens) * ratePerMTok / perMTok
+}
+
+func addUnitCost(breakdown map[string]float64, key string, units float64, rate float64) {
+	if units <= 0 || rate == 0 {
+		return
+	}
+	breakdown[key] += units * rate
+}
+
+func addImageCost(breakdown map[string]float64, images int, rates Rates) {
+	if images <= 0 {
+		return
+	}
+	if rates.OutputPerImage != 0 {
+		breakdown["output_images"] += float64(images) * rates.OutputPerImage
+		return
+	}
+	if rates.InputPerImage != 0 {
+		breakdown["input_images"] += float64(images) * rates.InputPerImage
+	}
+}
+
+func additionalCost(breakdown map[string]float64, name string, count int, rates map[string]float64) {
+	if count <= 0 || len(rates) == 0 {
+		return
+	}
+	canonical := strings.TrimSpace(name)
+	if canonical == "" {
+		return
+	}
+	if rate, ok := rates[canonical]; ok {
+		breakdown[canonical] += float64(count) * rate
+		return
+	}
+	if rate, ok := rates[canonical+"_per_call"]; ok {
+		breakdown[canonical] += float64(count) * rate
+		return
+	}
+	if rate, ok := rates[canonical+"_per_1k_calls"]; ok {
+		breakdown[canonical] += float64(count) * rate / 1000
+		return
+	}
+	if rate, ok := rates[canonical+"_per_container_hour"]; ok {
+		breakdown[canonical] += float64(count) * rate
+	}
+}
+
+func inRange(tokens int, bounds [2]int) bool {
+	lo := bounds[0]
+	hi := bounds[1]
+	if tokens < lo {
+		return false
+	}
+	if hi <= 0 {
+		return true
+	}
+	return tokens < hi
+}
+
+func defaultCurrency(currency string) string {
+	if strings.TrimSpace(currency) == "" {
+		return "USD"
+	}
+	return strings.TrimSpace(currency)
+}
+
+func missingResult(status string) EstimateResult {
+	if status == "" {
+		status = LookupMiss
+	}
+	return EstimateResult{
+		Currency:     "USD",
+		Source:       SourceMissing,
+		BreakdownUSD: map[string]float64{},
+		LookupStatus: status,
+	}
+}
+
+func hasBillableActivity(req EstimateRequest) bool {
+	return req.InputTokens > 0 ||
+		req.CachedInputTokens > 0 ||
+		req.CacheWrite5mTokens > 0 ||
+		req.CacheWrite1hTokens > 0 ||
+		req.OutputTokens > 0 ||
+		req.ReasoningTokens > 0 ||
+		req.InputImageTokens > 0 ||
+		req.OutputImageTokens > 0 ||
+		req.AudioSeconds > 0 ||
+		req.VideoSeconds > 0 ||
+		req.Characters > 0 ||
+		req.Images > 0 ||
+		len(req.UnitCounts) > 0
+}
+
+func roundUSD(value float64) float64 {
+	return math.Round(value*1_000_000_000) / 1_000_000_000
+}

--- a/internal/pricing/estimator_test.go
+++ b/internal/pricing/estimator_test.go
@@ -1,0 +1,103 @@
+package pricing
+
+import "testing"
+
+func TestEstimateChatCacheReasoningAndTiers(t *testing.T) {
+	catalog, err := LoadBundled()
+	if err != nil {
+		t.Fatalf("LoadBundled() error = %v", err)
+	}
+
+	result := catalog.Estimate(EstimateRequest{
+		Model:              "openai/o3",
+		Tier:               "flex",
+		InputTokens:        1000,
+		CachedInputTokens:  100,
+		CacheWrite5mTokens: 50,
+		OutputTokens:       500,
+		ReasoningTokens:    250,
+	})
+
+	want := 0.00085 + 0.000025 + 0.002 + 0.001
+	if !closeEnough(result.TotalUSD, want) {
+		t.Fatalf("expected %.9f, got %.9f (%#v)", want, result.TotalUSD, result.BreakdownUSD)
+	}
+	if result.Source != SourceTable || result.LookupStatus != LookupHit {
+		t.Fatalf("unexpected source/status: %#v", result)
+	}
+}
+
+func TestEstimateTieredDeploymentAdditionalAndUnits(t *testing.T) {
+	catalog, err := LoadBundled()
+	if err != nil {
+		t.Fatalf("LoadBundled() error = %v", err)
+	}
+
+	qwen := catalog.Estimate(EstimateRequest{
+		Model:        "qwen/qwen3-max",
+		InputTokens:  64000,
+		OutputTokens: 1000,
+	})
+	if qwen.EffectiveBand != "lte_128k" {
+		t.Fatalf("expected lte_128k band, got %q", qwen.EffectiveBand)
+	}
+	if !closeEnough(qwen.TotalUSD, 0.1656) {
+		t.Fatalf("unexpected qwen cost %.9f", qwen.TotalUSD)
+	}
+
+	anthropic := catalog.Estimate(EstimateRequest{
+		Model:        "anthropic/claude-sonnet-4-6",
+		Deployment:   "us",
+		InputTokens:  1000,
+		OutputTokens: 1000,
+		UnitCounts:   map[string]int{"web_search": 1000},
+	})
+	if !closeEnough(anthropic.TotalUSD, 10.0198) {
+		t.Fatalf("unexpected anthropic cost %.9f (%#v)", anthropic.TotalUSD, anthropic.BreakdownUSD)
+	}
+
+	dalle := catalog.Estimate(EstimateRequest{Model: "openai/dall-e-3", Images: 2})
+	if !closeEnough(dalle.TotalUSD, 0.08) {
+		t.Fatalf("unexpected image cost %.9f", dalle.TotalUSD)
+	}
+
+	whisper := catalog.Estimate(EstimateRequest{Model: "openai/whisper-1", AudioSeconds: 60})
+	if !closeEnough(whisper.TotalUSD, 0.006) {
+		t.Fatalf("unexpected whisper cost %.9f", whisper.TotalUSD)
+	}
+
+	tts := catalog.Estimate(EstimateRequest{Model: "openai/tts-1", Characters: 1000})
+	if !closeEnough(tts.TotalUSD, 0.015) {
+		t.Fatalf("unexpected tts cost %.9f", tts.TotalUSD)
+	}
+
+	video := catalog.Estimate(EstimateRequest{Model: "bytedance/seedance-2-0", VideoSeconds: 5})
+	if !closeEnough(video.TotalUSD, 0.70) {
+		t.Fatalf("unexpected video cost %.9f", video.TotalUSD)
+	}
+}
+
+func TestEstimateMissingAndWildcard(t *testing.T) {
+	catalog, err := LoadBundled()
+	if err != nil {
+		t.Fatalf("LoadBundled() error = %v", err)
+	}
+
+	missing := catalog.Estimate(EstimateRequest{Model: "unknown/model", InputTokens: 100, OutputTokens: 100})
+	if missing.TotalUSD != 0 || missing.Source != SourceMissing || missing.LookupStatus != LookupMiss {
+		t.Fatalf("unexpected missing result %#v", missing)
+	}
+
+	ollama := catalog.Estimate(EstimateRequest{Model: "ollama/llama3.3", InputTokens: 100, OutputTokens: 100})
+	if ollama.TotalUSD != 0 || ollama.Source != SourceTable || ollama.LookupStatus != LookupGlobHit {
+		t.Fatalf("unexpected ollama result %#v", ollama)
+	}
+}
+
+func closeEnough(got float64, want float64) bool {
+	const epsilon = 0.000000001
+	if got > want {
+		return got-want < epsilon
+	}
+	return want-got < epsilon
+}

--- a/internal/pricing/loader.go
+++ b/internal/pricing/loader.go
@@ -1,0 +1,218 @@
+package pricing
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/JiaCheng2004/Polaris/internal/config"
+	"gopkg.in/yaml.v3"
+)
+
+func Load(path string) (*Catalog, []string, error) {
+	entries := map[string]Entry{}
+	var sources []string
+	var warnings []string
+
+	bundled, err := fs.Glob(embeddedData, "data/*.yaml")
+	if err != nil {
+		return nil, nil, fmt.Errorf("list embedded pricing data: %w", err)
+	}
+	sort.Strings(bundled)
+	for _, name := range bundled {
+		data, err := embeddedData.ReadFile(name)
+		if err != nil {
+			return nil, warnings, fmt.Errorf("read embedded pricing data %s: %w", name, err)
+		}
+		parsed, err := parseFile(data, name)
+		if err != nil {
+			return nil, warnings, err
+		}
+		mergeEntries(entries, parsed.Models)
+		sources = append(sources, name)
+	}
+
+	if strings.TrimSpace(path) != "" {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, warnings, fmt.Errorf("read pricing file %s: %w", path, err)
+		}
+		expanded, envWarnings := config.ExpandEnv(string(data))
+		warnings = append(warnings, envWarnings...)
+		parsed, err := parseFile([]byte(expanded), path)
+		if err != nil {
+			return nil, warnings, err
+		}
+		mergeEntries(entries, parsed.Models)
+		sources = append(sources, path)
+	}
+
+	return newCatalog(entries, time.Now().UTC(), sources), uniqueSorted(warnings), nil
+}
+
+func LoadBundled() (*Catalog, error) {
+	catalog, _, err := Load("")
+	return catalog, err
+}
+
+func parseFile(data []byte, source string) (*File, error) {
+	var parsed File
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&parsed); err != nil {
+		return nil, fmt.Errorf("decode pricing yaml %s: %w", source, err)
+	}
+	if err := validateFile(parsed); err != nil {
+		return nil, fmt.Errorf("validate pricing yaml %s: %w", source, err)
+	}
+	normalizeFile(&parsed)
+	return &parsed, nil
+}
+
+func mergeEntries(dst map[string]Entry, src map[string]Entry) {
+	for key, entry := range src {
+		dst[strings.TrimSpace(key)] = entry
+	}
+}
+
+func validateFile(file File) error {
+	if file.Version != 1 {
+		return fmt.Errorf("version must be 1")
+	}
+	if len(file.Models) == 0 {
+		return fmt.Errorf("models must not be empty")
+	}
+	for key, entry := range file.Models {
+		if err := validateEntry(key, entry); err != nil {
+			return fmt.Errorf("models.%s: %w", key, err)
+		}
+	}
+	return nil
+}
+
+func validateEntry(key string, entry Entry) error {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return fmt.Errorf("model key must not be empty")
+	}
+	if !strings.Contains(key, "/") {
+		return fmt.Errorf("model key must use provider/model form")
+	}
+	if strings.Contains(key, "*") && !strings.HasSuffix(key, "*") {
+		return fmt.Errorf("wildcard is only supported as a suffix")
+	}
+	if !validMode(entry.Mode) {
+		return fmt.Errorf("mode %q is invalid", entry.Mode)
+	}
+	if entry.Pricing != nil && len(entry.TieredPricing) > 0 {
+		return fmt.Errorf("pricing and tiered_pricing are mutually exclusive")
+	}
+	if entry.Pricing == nil && len(entry.TieredPricing) == 0 {
+		return fmt.Errorf("pricing or tiered_pricing is required")
+	}
+	if entry.Pricing != nil {
+		if err := validateRates(*entry.Pricing); err != nil {
+			return fmt.Errorf("pricing: %w", err)
+		}
+	}
+	for name, tier := range entry.Tiers {
+		if !validTier(name) {
+			return fmt.Errorf("tiers.%s is not a known tier", name)
+		}
+		if err := validateRates(tier); err != nil {
+			return fmt.Errorf("tiers.%s: %w", name, err)
+		}
+	}
+	for name, deployment := range entry.Deployments {
+		if strings.TrimSpace(name) == "" {
+			return fmt.Errorf("deployment name must not be empty")
+		}
+		if err := validateRates(deployment); err != nil {
+			return fmt.Errorf("deployments.%s: %w", name, err)
+		}
+	}
+	for index, tier := range entry.TieredPricing {
+		if tier.Range[0] < 0 || tier.Range[1] < 0 {
+			return fmt.Errorf("tiered_pricing[%d].range must not be negative", index)
+		}
+		if tier.Range[1] > 0 && tier.Range[0] > tier.Range[1] {
+			return fmt.Errorf("tiered_pricing[%d].range lower bound must be <= upper bound", index)
+		}
+		if err := validateRates(tier.Rates); err != nil {
+			return fmt.Errorf("tiered_pricing[%d]: %w", index, err)
+		}
+	}
+	for name, rate := range entry.AdditionalUnits {
+		if strings.TrimSpace(name) == "" {
+			return fmt.Errorf("additional_units keys must not be empty")
+		}
+		if rate < 0 {
+			return fmt.Errorf("additional_units.%s must not be negative", name)
+		}
+	}
+	return nil
+}
+
+func validateRates(rates Rates) error {
+	if rates.Multiplier < 0 {
+		return fmt.Errorf("multiplier must not be negative")
+	}
+	for name, value := range map[string]float64{
+		"input_per_mtok":              rates.InputPerMTok,
+		"output_per_mtok":             rates.OutputPerMTok,
+		"output_reasoning_per_mtok":   rates.OutputReasoningPerMTok,
+		"cache_read_per_mtok":         rates.CacheReadPerMTok,
+		"cache_write_5m_per_mtok":     rates.CacheWrite5mPerMTok,
+		"cache_write_1h_per_mtok":     rates.CacheWrite1hPerMTok,
+		"input_cache_hit_per_mtok":    rates.InputCacheHitPerMTok,
+		"input_image_token_per_mtok":  rates.InputImageTokenPerMTok,
+		"output_image_token_per_mtok": rates.OutputImageTokenPerMTok,
+		"input_per_audio_second":      rates.InputPerAudioSecond,
+		"output_per_audio_second":     rates.OutputPerAudioSecond,
+		"input_per_video_second":      rates.InputPerVideoSecond,
+		"output_per_video_second":     rates.OutputPerVideoSecond,
+		"input_per_character":         rates.InputPerCharacter,
+		"input_per_image":             rates.InputPerImage,
+		"output_per_image":            rates.OutputPerImage,
+		"output_per_pixel":            rates.OutputPerPixel,
+		"per_call":                    rates.PerCall,
+	} {
+		if value < 0 {
+			return fmt.Errorf("%s must not be negative", name)
+		}
+	}
+	return nil
+}
+
+func normalizeFile(file *File) {
+	for key, entry := range file.Models {
+		if strings.TrimSpace(entry.Currency) == "" {
+			entry.Currency = "USD"
+		}
+		file.Models[key] = entry
+	}
+}
+
+func uniqueSorted(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/pricing/schema.go
+++ b/internal/pricing/schema.go
@@ -1,0 +1,137 @@
+package pricing
+
+import "strings"
+
+const (
+	SourceTable        = "table"
+	SourceFallbackZero = "fallback_zero"
+	SourceMissing      = "missing"
+
+	LookupHit     = "hit"
+	LookupGlobHit = "glob_hit"
+	LookupMiss    = "miss"
+)
+
+type File struct {
+	Version int              `yaml:"version"`
+	Models  map[string]Entry `yaml:"models"`
+}
+
+type Entry struct {
+	Mode            string             `yaml:"mode"`
+	Currency        string             `yaml:"currency,omitempty"`
+	ContextWindow   int                `yaml:"context_window,omitempty"`
+	Source          string             `yaml:"source,omitempty"`
+	EffectiveFrom   string             `yaml:"effective_from,omitempty"`
+	EffectiveUntil  string             `yaml:"effective_until,omitempty"`
+	Notes           string             `yaml:"notes,omitempty"`
+	Pricing         *Rates             `yaml:"pricing,omitempty"`
+	Tiers           map[string]Rates   `yaml:"tiers,omitempty"`
+	TieredPricing   []TieredRates      `yaml:"tiered_pricing,omitempty"`
+	AdditionalUnits map[string]float64 `yaml:"additional_units,omitempty"`
+	Deployments     map[string]Rates   `yaml:"deployments,omitempty"`
+	Deprecation     *Deprecation       `yaml:"deprecation,omitempty"`
+}
+
+type Rates struct {
+	Multiplier float64 `yaml:"multiplier,omitempty"`
+
+	InputPerMTok           float64 `yaml:"input_per_mtok,omitempty"`
+	OutputPerMTok          float64 `yaml:"output_per_mtok,omitempty"`
+	OutputReasoningPerMTok float64 `yaml:"output_reasoning_per_mtok,omitempty"`
+
+	CacheReadPerMTok     float64 `yaml:"cache_read_per_mtok,omitempty"`
+	CacheWrite5mPerMTok  float64 `yaml:"cache_write_5m_per_mtok,omitempty"`
+	CacheWrite1hPerMTok  float64 `yaml:"cache_write_1h_per_mtok,omitempty"`
+	InputCacheHitPerMTok float64 `yaml:"input_cache_hit_per_mtok,omitempty"`
+
+	InputImageTokenPerMTok  float64 `yaml:"input_image_token_per_mtok,omitempty"`
+	OutputImageTokenPerMTok float64 `yaml:"output_image_token_per_mtok,omitempty"`
+
+	InputPerAudioSecond  float64 `yaml:"input_per_audio_second,omitempty"`
+	OutputPerAudioSecond float64 `yaml:"output_per_audio_second,omitempty"`
+	InputPerVideoSecond  float64 `yaml:"input_per_video_second,omitempty"`
+	OutputPerVideoSecond float64 `yaml:"output_per_video_second,omitempty"`
+	InputPerCharacter    float64 `yaml:"input_per_character,omitempty"`
+	InputPerImage        float64 `yaml:"input_per_image,omitempty"`
+	OutputPerImage       float64 `yaml:"output_per_image,omitempty"`
+	OutputPerPixel       float64 `yaml:"output_per_pixel,omitempty"`
+	PerCall              float64 `yaml:"per_call,omitempty"`
+}
+
+type TieredRates struct {
+	ID    string `yaml:"id,omitempty"`
+	Range [2]int `yaml:"range"`
+	Rates `yaml:",inline"`
+}
+
+type Deprecation struct {
+	Replacement string `yaml:"replacement,omitempty"`
+	Sunset      string `yaml:"sunset,omitempty"`
+}
+
+type EstimateRequest struct {
+	Model              string
+	Tier               string
+	Deployment         string
+	InputTokens        int
+	CachedInputTokens  int
+	CacheWrite5mTokens int
+	CacheWrite1hTokens int
+	OutputTokens       int
+	ReasoningTokens    int
+	InputImageTokens   int
+	OutputImageTokens  int
+	AudioSeconds       float64
+	VideoSeconds       float64
+	Characters         int
+	Images             int
+	UnitCounts         map[string]int
+}
+
+type EstimateResult struct {
+	TotalUSD      float64
+	Currency      string
+	Source        string
+	BreakdownUSD  map[string]float64
+	EffectiveTier string
+	EffectiveBand string
+	LookupStatus  string
+}
+
+type Estimator interface {
+	Estimate(req EstimateRequest) EstimateResult
+	Lookup(modelID string) (Entry, bool)
+}
+
+func validMode(mode string) bool {
+	switch strings.TrimSpace(mode) {
+	case "chat",
+		"embedding",
+		"embed",
+		"image",
+		"image_generation",
+		"audio",
+		"audio_transcription",
+		"audio_speech",
+		"voice",
+		"video",
+		"interpreting",
+		"music",
+		"podcast",
+		"notes",
+		"translation":
+		return true
+	default:
+		return false
+	}
+}
+
+func validTier(name string) bool {
+	switch strings.TrimSpace(name) {
+	case "batch", "flex", "priority", "standard":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/pricing/watcher.go
+++ b/internal/pricing/watcher.go
@@ -1,0 +1,54 @@
+package pricing
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+)
+
+func WatchFile(ctx context.Context, holder *Holder, path string, interval time.Duration, logger *slog.Logger) {
+	if holder == nil || strings.TrimSpace(path) == "" || interval <= 0 {
+		return
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	var lastMod time.Time
+	if info, err := os.Stat(path); err == nil {
+		lastMod = info.ModTime()
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			info, err := os.Stat(path)
+			if err != nil {
+				logger.Warn("pricing file stat failed", "path", path, "error", err)
+				continue
+			}
+			if !lastMod.IsZero() && !info.ModTime().After(lastMod) {
+				continue
+			}
+			catalog, warnings, err := Load(path)
+			if err != nil {
+				logger.Error("pricing reload failed", "path", path, "error", err)
+				lastMod = info.ModTime()
+				continue
+			}
+			for _, warning := range warnings {
+				logger.Warn("pricing warning", "warning", warning)
+			}
+			holder.Swap(catalog)
+			lastMod = info.ModTime()
+			logger.Info("pricing reloaded", "path", path, "sources", catalog.Sources())
+		}
+	}
+}

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -170,6 +170,7 @@ type RequestLog struct {
 	OutputTokens      int
 	TotalTokens       int
 	EstimatedCost     float64
+	CostSource        string
 	StatusCode        int
 	ErrorType         string
 	CreatedAt         time.Time
@@ -200,11 +201,12 @@ type ModelUsage struct {
 }
 
 type UsageReport struct {
-	TotalRequests int64        `json:"total_requests"`
-	TotalTokens   int64        `json:"total_tokens"`
-	TotalCost     float64      `json:"total_cost_usd"`
-	ByDay         []DailyUsage `json:"by_day,omitempty"`
-	ByModel       []ModelUsage `json:"by_model,omitempty"`
+	TotalRequests       int64            `json:"total_requests"`
+	TotalTokens         int64            `json:"total_tokens"`
+	TotalCost           float64          `json:"total_cost_usd"`
+	CostSourceBreakdown map[string]int64 `json:"cost_source_breakdown,omitempty"`
+	ByDay               []DailyUsage     `json:"by_day,omitempty"`
+	ByModel             []ModelUsage     `json:"by_model,omitempty"`
 }
 
 var (

--- a/internal/store/postgres/migrations/001_init.up.sql
+++ b/internal/store/postgres/migrations/001_init.up.sql
@@ -36,6 +36,7 @@ CREATE TABLE IF NOT EXISTS request_logs (
     output_tokens        INTEGER,
     total_tokens         INTEGER,
     estimated_cost       DOUBLE PRECISION,
+    cost_source          TEXT,
     status_code          INTEGER NOT NULL,
     error_type           TEXT,
     created_at           TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -184,8 +184,8 @@ func (s *Store) LogRequestBatch(ctx context.Context, logs []store.RequestLog) er
 		INSERT INTO request_logs (
 			id, request_id, key_id, project_id, model, modality, interface_family, token_source,
 			cache_status, fallback_model, trace_id, toolset, mcp_binding, provider_latency_ms, total_latency_ms,
-			input_tokens, output_tokens, total_tokens, estimated_cost, status_code, error_type, created_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)
+			input_tokens, output_tokens, total_tokens, estimated_cost, cost_source, status_code, error_type, created_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23)
 	`)
 	if err != nil {
 		return fmt.Errorf("prepare request log batch: %w", err)
@@ -221,6 +221,7 @@ func (s *Store) LogRequestBatch(ctx context.Context, logs []store.RequestLog) er
 			entry.OutputTokens,
 			entry.TotalTokens,
 			entry.EstimatedCost,
+			nullableString(entry.CostSource),
 			entry.StatusCode,
 			nullableString(entry.ErrorType),
 			entry.CreatedAt.UTC(),
@@ -355,6 +356,7 @@ func (s *Store) ensureControlPlaneUpgrade(ctx context.Context) error {
 		`ALTER TABLE request_logs ADD COLUMN IF NOT EXISTS trace_id TEXT;`,
 		`ALTER TABLE request_logs ADD COLUMN IF NOT EXISTS toolset TEXT;`,
 		`ALTER TABLE request_logs ADD COLUMN IF NOT EXISTS mcp_binding TEXT;`,
+		`ALTER TABLE request_logs ADD COLUMN IF NOT EXISTS cost_source TEXT;`,
 		`CREATE TABLE IF NOT EXISTS virtual_keys (
 			id TEXT PRIMARY KEY,
 			project_id TEXT NOT NULL REFERENCES projects(id),
@@ -1271,7 +1273,43 @@ func usageTotals(ctx context.Context, db *sql.DB, where string, args []any) (sto
 	if err := db.QueryRowContext(ctx, query, args...).Scan(&report.TotalRequests, &report.TotalTokens, &report.TotalCost); err != nil {
 		return store.UsageReport{}, fmt.Errorf("query usage totals: %w", err)
 	}
+	breakdown, err := usageCostSourceBreakdown(ctx, db, where, args)
+	if err != nil {
+		return store.UsageReport{}, err
+	}
+	report.CostSourceBreakdown = breakdown
 	return report, nil
+}
+
+func usageCostSourceBreakdown(ctx context.Context, db *sql.DB, where string, args []any) (map[string]int64, error) {
+	query := `
+		SELECT COALESCE(NULLIF(cost_source, ''), 'unknown') AS cost_source,
+		       COUNT(*) AS requests
+		FROM request_logs
+		LEFT JOIN api_keys ON api_keys.id = request_logs.key_id
+		LEFT JOIN virtual_keys ON virtual_keys.id = request_logs.key_id
+	`
+	query = appendWhereExpression(query, where)
+	query += " GROUP BY COALESCE(NULLIF(cost_source, ''), 'unknown')"
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query usage cost source breakdown: %w", err)
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	breakdown := map[string]int64{}
+	for rows.Next() {
+		var source string
+		var requests int64
+		if err := rows.Scan(&source, &requests); err != nil {
+			return nil, fmt.Errorf("scan usage cost source breakdown: %w", err)
+		}
+		breakdown[source] = requests
+	}
+	return breakdown, rows.Err()
 }
 
 func appendWhereClauses(query string, clauses []string) string {

--- a/internal/store/sqlite/migrations/001_init.up.sql
+++ b/internal/store/sqlite/migrations/001_init.up.sql
@@ -36,6 +36,7 @@ CREATE TABLE IF NOT EXISTS request_logs (
     output_tokens        INTEGER,
     total_tokens         INTEGER,
     estimated_cost       REAL,
+    cost_source          TEXT,
     status_code          INTEGER NOT NULL,
     error_type           TEXT,
     created_at           TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -172,8 +172,8 @@ func (s *Store) LogRequestBatch(ctx context.Context, logs []store.RequestLog) er
 		INSERT INTO request_logs (
 			id, request_id, key_id, project_id, model, modality, interface_family, token_source,
 			cache_status, fallback_model, trace_id, toolset, mcp_binding, provider_latency_ms, total_latency_ms,
-			input_tokens, output_tokens, total_tokens, estimated_cost, status_code, error_type, created_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			input_tokens, output_tokens, total_tokens, estimated_cost, cost_source, status_code, error_type, created_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`)
 	if err != nil {
 		return fmt.Errorf("prepare request log batch: %w", err)
@@ -209,6 +209,7 @@ func (s *Store) LogRequestBatch(ctx context.Context, logs []store.RequestLog) er
 			entry.OutputTokens,
 			entry.TotalTokens,
 			entry.EstimatedCost,
+			nullableString(entry.CostSource),
 			entry.StatusCode,
 			nullableString(entry.ErrorType),
 			entry.CreatedAt,
@@ -436,6 +437,7 @@ func (s *Store) ensureControlPlaneUpgrade(ctx context.Context) error {
 		"trace_id":         "TEXT",
 		"toolset":          "TEXT",
 		"mcp_binding":      "TEXT",
+		"cost_source":      "TEXT",
 	}
 	for column, columnType := range requestLogColumns {
 		exists, err := s.sqliteColumnExists(ctx, "request_logs", column)
@@ -1323,7 +1325,43 @@ func usageTotals(ctx context.Context, db *sql.DB, where string, args []any) (sto
 	if err := db.QueryRowContext(ctx, query, args...).Scan(&report.TotalRequests, &report.TotalTokens, &report.TotalCost); err != nil {
 		return store.UsageReport{}, fmt.Errorf("query usage totals: %w", err)
 	}
+	breakdown, err := usageCostSourceBreakdown(ctx, db, where, args)
+	if err != nil {
+		return store.UsageReport{}, err
+	}
+	report.CostSourceBreakdown = breakdown
 	return report, nil
+}
+
+func usageCostSourceBreakdown(ctx context.Context, db *sql.DB, where string, args []any) (map[string]int64, error) {
+	query := `
+		SELECT COALESCE(NULLIF(cost_source, ''), 'unknown') AS cost_source,
+		       COUNT(*) AS requests
+		FROM request_logs
+		LEFT JOIN api_keys ON api_keys.id = request_logs.key_id
+		LEFT JOIN virtual_keys ON virtual_keys.id = request_logs.key_id
+	`
+	query = appendWhereExpression(query, where)
+	query += " GROUP BY COALESCE(NULLIF(cost_source, ''), 'unknown')"
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query usage cost source breakdown: %w", err)
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	breakdown := map[string]int64{}
+	for rows.Next() {
+		var source string
+		var requests int64
+		if err := rows.Scan(&source, &requests); err != nil {
+			return nil, fmt.Errorf("scan usage cost source breakdown: %w", err)
+		}
+		breakdown[source] = requests
+	}
+	return breakdown, rows.Err()
 }
 
 func appendWhereClauses(query string, clauses []string) string {

--- a/internal/store/sqlite/sqlite_test.go
+++ b/internal/store/sqlite/sqlite_test.go
@@ -187,7 +187,7 @@ func TestSQLiteMigrateUpgradesExistingRequestLogsSchema(t *testing.T) {
 	if err := sqliteStore.Migrate(ctx); err != nil {
 		t.Fatalf("Migrate() error = %v", err)
 	}
-	for _, column := range []string{"interface_family", "token_source", "cache_status", "fallback_model", "trace_id", "toolset", "mcp_binding"} {
+	for _, column := range []string{"interface_family", "token_source", "cache_status", "fallback_model", "trace_id", "toolset", "mcp_binding", "cost_source"} {
 		exists, err := sqliteStore.sqliteColumnExists(ctx, "request_logs", column)
 		if err != nil {
 			t.Fatalf("sqliteColumnExists(%s) error = %v", column, err)

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -1201,13 +1201,14 @@ type ModelUsage struct {
 }
 
 type UsageReport struct {
-	From          string       `json:"from"`
-	To            string       `json:"to"`
-	TotalRequests int64        `json:"total_requests"`
-	TotalTokens   int64        `json:"total_tokens"`
-	TotalCostUSD  float64      `json:"total_cost_usd"`
-	ByDay         []DailyUsage `json:"by_day,omitempty"`
-	ByModel       []ModelUsage `json:"by_model,omitempty"`
+	From                string           `json:"from"`
+	To                  string           `json:"to"`
+	TotalRequests       int64            `json:"total_requests"`
+	TotalTokens         int64            `json:"total_tokens"`
+	TotalCostUSD        float64          `json:"total_cost_usd"`
+	CostSourceBreakdown map[string]int64 `json:"cost_source_breakdown,omitempty"`
+	ByDay               []DailyUsage     `json:"by_day,omitempty"`
+	ByModel             []ModelUsage     `json:"by_model,omitempty"`
 }
 
 type CreateKeyRequest struct {

--- a/schema/cue/polaris.config.cue
+++ b/schema/cue/polaris.config.cue
@@ -54,6 +54,11 @@ package polaris
 		mcp?: {
 			enabled?: bool
 		}
+		pricing?: {
+			file?: string
+			reload_interval_seconds?: int & >=0
+			fail_on_missing?: bool
+		}
 		observability?: _
 	}
 

--- a/schema/polaris.config.schema.json
+++ b/schema/polaris.config.schema.json
@@ -39,6 +39,7 @@
             "enabled": { "type": "boolean" }
           }
         },
+        "pricing": { "$ref": "#/$defs/pricing" },
         "observability": { "$ref": "#/$defs/observability" }
       }
     },
@@ -150,6 +151,15 @@
             }
           }
         }
+      }
+    },
+    "pricing": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "file": { "type": "string" },
+        "reload_interval_seconds": { "type": "integer", "minimum": 0 },
+        "fail_on_missing": { "type": "boolean" }
       }
     },
     "observability": {

--- a/spec/openapi/polaris.v1.yaml
+++ b/spec/openapi/polaris.v1.yaml
@@ -283,8 +283,11 @@ components:
         archived_at: {type: string}
     UsageReport:
       type: object
-      required: [total_requests, total_tokens, total_cost]
+      required: [total_requests, total_tokens, total_cost_usd]
       properties:
         total_requests: {type: integer}
         total_tokens: {type: integer}
-        total_cost: {type: number}
+        total_cost_usd: {type: number}
+        cost_source_breakdown:
+          type: object
+          additionalProperties: {type: integer}

--- a/tests/integration/pricing_hot_reload_test.go
+++ b/tests/integration/pricing_hot_reload_test.go
@@ -1,0 +1,59 @@
+package integration
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/JiaCheng2004/Polaris/internal/pricing"
+)
+
+func TestPricingHotReloadSwapsCatalog(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pricing.yaml")
+	writePricingFile(t, path, 1)
+
+	catalog, _, err := pricing.Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	holder := pricing.NewHolder(catalog)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go pricing.WatchFile(ctx, holder, path, 10*time.Millisecond, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	if got := holder.Estimate(pricing.EstimateRequest{Model: "openai/gpt-4o", InputTokens: 1_000_000}).TotalUSD; got != 1 {
+		t.Fatalf("expected initial override cost 1, got %.2f", got)
+	}
+
+	time.Sleep(20 * time.Millisecond)
+	writePricingFile(t, path, 9)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		got := holder.Estimate(pricing.EstimateRequest{Model: "openai/gpt-4o", InputTokens: 1_000_000}).TotalUSD
+		if got == 9 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("pricing override did not reload before deadline")
+}
+
+func writePricingFile(t *testing.T, path string, inputRate int) {
+	t.Helper()
+	data := []byte(`version: 1
+models:
+  openai/gpt-4o:
+    mode: chat
+    pricing: { input_per_mtok: ` + strconv.Itoa(inputRate) + `, output_per_mtok: 1 }
+`)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write pricing file: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- New `internal/pricing` package: YAML-driven cost catalog with bundled defaults for 10 providers + operator override file with hot-reload.
- Wires the catalog through the runtime holder so every successful request emits a per-dimension cost estimate (input/output/cache/reasoning/image/audio/video/character tokens).
- `cost_source` recorded in `request_logs` (column added in both Postgres and SQLite migrations; idempotent `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` for already-deployed instances).
- Surfaced in `/v1/usage` (`cost_source_breakdown`) and Prometheus (`polaris_estimated_cost_usd{cost_source=...}`, `polaris_pricing_lookups_total`).
- `enforcePricingPolicy` gates dispatch when `pricing.fail_on_missing=true`. Default behavior is graceful degradation to `$0` with `cost_source=missing`.
- Public API: `pkg/client.UsageReport`, OpenAPI schema, CUE/JSON config schemas all carry the new field.
- New operator guide `docs/PRICING.md`; `docs/CONFIGURATION.md` gains a pricing subsection.
- gosec G304 allowlist entry for the operator-supplied override path (same trust model as the gateway config file).

## Why one PR (not split)

The clusters are tightly coupled — splitting them produces intermediate states where the gateway either compiles without pricing wired (the state `main` was actually in for two days; see context below) or doesn't compile at all. Single focused PR is the right unit.

## Context — why this took two passes

This WIP existed in the working tree for a while. Two days ago it briefly contaminated the GHCR publish-image PR via leftover `internal/pricing` imports in `cmd/polaris/main.go`, which I surgically backed out in commit `4c322f1` to fix the publish workflow. That revert correctly removed the imports but **never re-applied them after publish-image landed**. Result: the pricing engine library was complete and tested, but the binary entrypoint was not wiring it up — `cfg.Pricing.File` was being parsed and silently ignored.

This PR restores the wiring (`pricing.Load` + `NewHolderWithPricing` + `pricing.WatchFile` goroutine in `cmd/polaris/main.go`) on top of the previously-complete WIP.

## Handler enforcement design (clarification for reviewers)

`enforcePricingPolicy` is called from exactly two places:
- `internal/gateway/handler/multimodal_helpers.go:51` — inside `resolveEndpointModel`, which all 24+ multimodal handler entrypoints flow through.
- `internal/gateway/handler/conversation_execution.go:116` — the chat/responses/messages path, which uses a different resolution flow that bypasses `resolveEndpointModel`.

These two call sites cover every model-resolving entrypoint in the gateway. Added an explanatory comment near `enforcePricingPolicy` to prevent future "missing call" worries.

## Test plan

- [x] `make fmt-check` — clean
- [x] `make lint` (golangci-lint v2.11.4) — 0 issues
- [x] `make security-check` — passes after adding the G304 allowlist entry for `internal/pricing/loader.go:Load`
- [x] `make config-check` — passes
- [x] `make contract-check` — passes (OpenAPI vs registered routes vs golden fixtures)
- [x] `go test -race -count=1 ./...` — all packages green, including:
  - `internal/pricing` (13 unit tests across catalog, estimator, data, schema)
  - `internal/gateway TestPhase3UsageAggregatesMixedModalities` (HTTP-level cost-source aggregation through chat + embed + image + audio paths)
  - `tests/integration/pricing_hot_reload_test.go` (file-watch swap)
- [x] `make stack-validate STACK={local,prod,dev}` — all three pass
- [x] `docker build -f deployments/Dockerfile .` — builds; `docker run --rm <img> --version` works
- [x] Local boot of `./polaris --config ./config/polaris.yaml` — `/health` returns 200, no pricing-related errors
- [ ] CI green on this PR
- [ ] Post-merge: `publish-image.yml` produces fresh `:edge` and `:sha-<short>` containing the pricing engine
- [ ] Post-merge: pull `ghcr.io/jiacheng2004/polaris:edge`, hit a chat completion against a configured provider, confirm `request_logs.cost_source` is set and `/metrics` shows `polaris_estimated_cost_usd{cost_source="table",...}`

## Notes

- `make panic-scan` skipped locally because `rg` (ripgrep) isn't installed on my dev machine; CI has it.
- Bundled catalog covers anthropic, openai, google, bytedance, xai, qwen, deepseek, ollama, elevenlabs, minimax. Other configured providers (vertex, bedrock, nvidia, replicate, moonshot, glm, mistral, openrouter, together, groq, fireworks, featherless) will record `cost_source=missing` and `$0` until operators supply override entries.
- BLUEPRINT.md §16 explicitly approves this work: *"Treat the pricing engine and its bundled cost tables as landed operational infrastructure; keep provider/model price updates in YAML with source and effective-date provenance."*
